### PR TITLE
feat: 导入 KMate(kmate.io)km3.dat 数据库

### DIFF
--- a/KindleMate2.Application/DependencyInjection.cs
+++ b/KindleMate2.Application/DependencyInjection.cs
@@ -42,6 +42,7 @@ public static class DependencyInjection {
         // ── Application-level Managers (Singleton — stateless coordinators) ──
         services.AddSingleton<IVocabDatabaseServiceFactory, VocabDatabaseServiceFactory>();
         services.AddSingleton<IKmDatabaseServiceFactory, KmDatabaseServiceFactory>();
+        services.AddSingleton<IKmateDatabaseServiceFactory, KmateDatabaseServiceFactory>();
         services.AddSingleton<IDeviceManager>(sp => {
             var versionFilePath = Path.Combine(AppConstants.SystemPathName, AppConstants.VersionFileName);
             return new DeviceManager(versionFilePath);
@@ -58,6 +59,7 @@ public static class DependencyInjection {
                 sp.GetRequiredService<ILookupService>(),
                 sp.GetRequiredService<IVocabDatabaseServiceFactory>(),
                 sp.GetRequiredService<IKmDatabaseServiceFactory>(),
+                sp.GetRequiredService<IKmateDatabaseServiceFactory>(),
                 importPath);
         });
         services.AddSingleton<IDataDisplayService, DataDisplayService>();

--- a/KindleMate2.Application/Services/IImportManager.cs
+++ b/KindleMate2.Application/Services/IImportManager.cs
@@ -5,4 +5,5 @@ public interface IImportManager {
     string ImportKindleClippings(string clippingsPath);
     string ImportKindleWords(string kindleWordsPath);
     string ImportKmDatabase(string filePath);
+    string ImportKmateDatabase(string filePath);
 }

--- a/KindleMate2.Application/Services/IKmateDatabaseServiceFactory.cs
+++ b/KindleMate2.Application/Services/IKmateDatabaseServiceFactory.cs
@@ -1,0 +1,11 @@
+using KindleMate2.Application.Services.KM2DB;
+
+namespace KindleMate2.Application.Services;
+
+/// <summary>
+/// Factory for creating <see cref="KmateDatabaseService"/> instances wired with
+/// the target KM2 repositories and a read-only path to the KMate km3.dat source.
+/// </summary>
+public interface IKmateDatabaseServiceFactory {
+    KmateDatabaseService Create(string km3DbPath);
+}

--- a/KindleMate2.Application/Services/ImportManager.cs
+++ b/KindleMate2.Application/Services/ImportManager.cs
@@ -16,11 +16,13 @@ public class ImportManager : IImportManager {
     private readonly ILookupService _lookupService;
     private readonly IVocabDatabaseServiceFactory _vocabDatabaseServiceFactory;
     private readonly IKmDatabaseServiceFactory _kmDatabaseServiceFactory;
+    private readonly IKmateDatabaseServiceFactory _kmateDatabaseServiceFactory;
     private readonly string _importPath;
 
     public ImportManager(IKm2DatabaseService km2DatabaseService, IClippingService clippingService, IVocabService vocabService,
         IOriginalClippingLineService originalClippingLineService, ILookupService lookupService,
         IVocabDatabaseServiceFactory vocabDatabaseServiceFactory, IKmDatabaseServiceFactory kmDatabaseServiceFactory,
+        IKmateDatabaseServiceFactory kmateDatabaseServiceFactory,
         string importPath) {
         _km2DatabaseService = km2DatabaseService;
         _clippingService = clippingService;
@@ -29,6 +31,7 @@ public class ImportManager : IImportManager {
         _lookupService = lookupService;
         _vocabDatabaseServiceFactory = vocabDatabaseServiceFactory;
         _kmDatabaseServiceFactory = kmDatabaseServiceFactory;
+        _kmateDatabaseServiceFactory = kmateDatabaseServiceFactory;
         _importPath = importPath;
     }
 
@@ -95,6 +98,32 @@ public class ImportManager : IImportManager {
         }
 
         if (!kmDatabaseService.ImportFromKmDatabase()) {
+            return string.Empty;
+        }
+
+        _km2DatabaseService.CleanDatabase(string.Empty, out _);
+        _km2DatabaseService.UpdateFrequency();
+
+        clippingsCount = _clippingService.GetCount() - clippingsCount;
+        vocabCount = _vocabService.GetCount() - vocabCount;
+        var message = Strings.Parsed_X + Strings.Space + (clippingsCount + vocabCount) + Strings.Space + Strings.X_Records + Strings.Symbol_Comma +
+                      Strings.Imported_X + Strings.Space + clippingsCount + Strings.Space + Strings.X_Clippings + Strings.Symbol_Comma +
+                      vocabCount + Strings.Space + Strings.X_Vocabs;
+        return message;
+    }
+
+    public string ImportKmateDatabase(string filePath) {
+        var kmateDatabaseService = _kmateDatabaseServiceFactory.Create(filePath);
+
+        var clippingsCount = _clippingService.GetCount();
+        var vocabCount = _vocabService.GetCount();
+
+        if (File.Exists(filePath)) {
+            var backupFilePath = Path.Combine(_importPath, "KMate_" + DateTimeHelper.GetCurrentTimestamp() + FileExtension.DAT);
+            File.Copy(filePath, backupFilePath, true);
+        }
+
+        if (!kmateDatabaseService.ImportFromKmateDatabase()) {
             return string.Empty;
         }
 

--- a/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
@@ -51,10 +51,11 @@ namespace KindleMate2.Application.Services.KM2DB {
                     // transaction per table via the repositories' batched Add overloads.
                     var targetClippings = _clippingRepository.GetAll();
                     var targetClippingKeys = targetClippings.Select(c => c.Key).ToHashSet();
-                    var targetClippingContents = targetClippings
-                        .Where(c => c.Content != null)
-                        .Select(c => c.Content!)
-                        .ToHashSet();
+                    // Dedup scope is per (book, author, content), not global content: the same
+                    // sentence highlighted in two different books are two distinct highlights and
+                    // must both be kept. A true duplicate import (same book re-imported from a
+                    // device/cloud/source) still shares book+author+content and is skipped.
+                    var targetBookContents = targetClippings.Select(ComposeBookContentKey).ToHashSet();
 
                     var clippingCandidates = new List<Clipping>();
                     foreach (Clipping kmClipping in data.Clippings) {
@@ -62,12 +63,12 @@ namespace KindleMate2.Application.Services.KM2DB {
                             continue;
                         }
                         if (!targetClippingKeys.Contains(kmClipping.Key) &&
-                            !targetClippingContents.Contains(kmClipping.Content)) {
+                            !targetBookContents.Contains(ComposeBookContentKey(kmClipping))) {
                             clippingCandidates.Add(kmClipping);
                             // Keep the dedup sets in sync so duplicates later in the same source
                             // cannot be added twice (the batched INSERT runs in one transaction).
                             targetClippingKeys.Add(kmClipping.Key);
-                            targetClippingContents.Add(kmClipping.Content);
+                            targetBookContents.Add(ComposeBookContentKey(kmClipping));
                         }
                     }
                     if (clippingCandidates.Count > 0) {
@@ -141,6 +142,13 @@ namespace KindleMate2.Application.Services.KM2DB {
         private static string ComposePair(string wordKey, string? timestamp) {
             // \u0001 is used as a separator that cannot appear in a word_key.
             return wordKey + "\u0001" + (timestamp ?? string.Empty);
+        }
+
+        private static string ComposeBookContentKey(Clipping clipping) {
+            // (book, author, content) scope; an empty author degrades to (book, "", content).
+            return (clipping.BookName ?? string.Empty) + "\u0001" +
+                   (clipping.AuthorName ?? string.Empty) + "\u0001" +
+                   clipping.Content;
         }
     }
 }

--- a/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
@@ -1,0 +1,133 @@
+using KindleMate2.Domain.Entities.KM2DB;
+using KindleMate2.Domain.Interfaces.KM2DB;
+using KindleMate2.Infrastructure.Helpers;
+using KindleMate2.Infrastructure.Repositories.KM2DB;
+
+namespace KindleMate2.Application.Services.KM2DB {
+    /// <summary>
+    /// Imports data from a KMate (kmate.io) <c>km3.dat</c> database into the current KM2 database.
+    /// </summary>
+    /// <remarks>
+    /// Source rows are mapped by <see cref="KmateSourceReader"/> (the km3 schema differs from the KM2
+    /// target schema, so the shared repositories cannot read it directly). Target writes go through the
+    /// regular KM2 repositories. Deduplication mirrors <see cref="KmDatabaseService"/> with three
+    /// km3-specific corrections:
+    /// <list type="bullet">
+    /// <item><c>original_clipping_lines</c> are only imported when their key belongs to an accepted
+    /// <c>clippings</c> row — KMate leaves orphan lines behind after its own duplicate cleanup;</item>
+    /// <item><c>vocab</c> uses the word_key-derived TEXT id produced by the reader (source id is INTEGER);</item>
+    /// <item><c>lookups</c> are deduplicated on (word_key, timestamp) to respect the target UNIQUE constraint.</item>
+    /// </list>
+    /// The source file is only ever opened read-only.
+    /// </remarks>
+    public class KmateDatabaseService {
+        private readonly IClippingRepository _clippingRepository;
+        private readonly ILookupRepository _lookupRepository;
+        private readonly IOriginalClippingLineRepository _originalClippingLineRepository;
+        private readonly IVocabRepository _vocabRepository;
+        private readonly string _sourcePath;
+
+        public KmateDatabaseService(
+            IClippingRepository clippingRepository,
+            ILookupRepository lookupRepository,
+            IOriginalClippingLineRepository originalClippingLineRepository,
+            IVocabRepository vocabRepository,
+            string sourcePath) {
+            _clippingRepository = clippingRepository;
+            _lookupRepository = lookupRepository;
+            _originalClippingLineRepository = originalClippingLineRepository;
+            _vocabRepository = vocabRepository;
+            _sourcePath = sourcePath;
+        }
+
+        public bool ImportFromKmateDatabase() {
+            try {
+                if (!KmateSourceReader.TryRead(_sourcePath, out var data, out _)) {
+                    return false;
+                }
+
+                if (data.Clippings.Count > 0 || data.OriginalClippingLines.Count > 0) {
+                    // Pre-fetch target data for O(1) in-memory dedup checks.
+                    var targetClippings = _clippingRepository.GetAll();
+                    var targetClippingKeys = targetClippings.Select(c => c.Key).ToHashSet();
+                    var targetClippingContents = targetClippings
+                        .Where(c => c.Content != null)
+                        .Select(c => c.Content!)
+                        .ToHashSet();
+
+                    foreach (Clipping kmClipping in data.Clippings) {
+                        if (string.IsNullOrEmpty(kmClipping.Content)) {
+                            continue;
+                        }
+                        if (!targetClippingKeys.Contains(kmClipping.Key) &&
+                            !targetClippingContents.Contains(kmClipping.Content)) {
+                            if (_clippingRepository.Add(kmClipping)) {
+                                // Keep the dedup sets in sync so a duplicate key/content later
+                                // in the same source file cannot trip the PRIMARY KEY constraint.
+                                targetClippingKeys.Add(kmClipping.Key);
+                                targetClippingContents.Add(kmClipping.Content);
+                            }
+                        }
+                    }
+
+                    var targetOriginalKeys = _originalClippingLineRepository.GetAllKeys().ToHashSet();
+                    foreach (OriginalClippingLine kmLine in data.OriginalClippingLines) {
+                        // Skip orphan lines whose key was removed from clippings by KMate's cleanup.
+                        if (!targetClippingKeys.Contains(kmLine.Key)) {
+                            continue;
+                        }
+                        if (!targetOriginalKeys.Contains(kmLine.Key)) {
+                            if (_originalClippingLineRepository.Add(kmLine)) {
+                                targetOriginalKeys.Add(kmLine.Key);
+                            }
+                        }
+                    }
+                }
+
+                if (data.Lookups.Count > 0) {
+                    var targetLookupPairs = _lookupRepository.GetAll()
+                        .Where(l => l.WordKey != null)
+                        .Select(l => ComposePair(l.WordKey!, l.Timestamp))
+                        .ToHashSet();
+
+                    foreach (Lookup kmLookup in data.Lookups) {
+                        if (string.IsNullOrWhiteSpace(kmLookup.WordKey)) {
+                            continue;
+                        }
+                        var pair = ComposePair(kmLookup.WordKey, kmLookup.Timestamp);
+                        if (!targetLookupPairs.Contains(pair)) {
+                            if (_lookupRepository.Add(kmLookup)) {
+                                targetLookupPairs.Add(pair);
+                            }
+                        }
+                    }
+                }
+
+                if (data.Vocabs.Count > 0) {
+                    var targetVocabIds = _vocabRepository.GetAll().Select(v => v.Id).ToHashSet();
+
+                    foreach (Vocab kmVocab in data.Vocabs) {
+                        if (string.IsNullOrWhiteSpace(kmVocab.Id)) {
+                            continue;
+                        }
+                        if (!targetVocabIds.Contains(kmVocab.Id)) {
+                            if (_vocabRepository.Add(kmVocab)) {
+                                targetVocabIds.Add(kmVocab.Id);
+                            }
+                        }
+                    }
+                }
+
+                return true;
+            } catch (Exception e) {
+                Console.WriteLine(StringHelper.GetExceptionMessage(nameof(ImportFromKmateDatabase), e));
+                return false;
+            }
+        }
+
+        private static string ComposePair(string wordKey, string? timestamp) {
+            // \u0001 is used as a separator that cannot appear in a word_key.
+            return wordKey + "\u0001" + (timestamp ?? string.Empty);
+        }
+    }
+}

--- a/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
@@ -47,7 +47,8 @@ namespace KindleMate2.Application.Services.KM2DB {
                 }
 
                 if (data.Clippings.Count > 0 || data.OriginalClippingLines.Count > 0) {
-                    // Pre-fetch target data for O(1) in-memory dedup checks.
+                    // Pre-fetch target data for O(1) in-memory dedup checks, then write in one
+                    // transaction per table via the repositories' batched Add overloads.
                     var targetClippings = _clippingRepository.GetAll();
                     var targetClippingKeys = targetClippings.Select(c => c.Key).ToHashSet();
                     var targetClippingContents = targetClippings
@@ -55,21 +56,25 @@ namespace KindleMate2.Application.Services.KM2DB {
                         .Select(c => c.Content!)
                         .ToHashSet();
 
+                    var clippingCandidates = new List<Clipping>();
                     foreach (Clipping kmClipping in data.Clippings) {
                         if (string.IsNullOrEmpty(kmClipping.Content)) {
                             continue;
                         }
                         if (!targetClippingKeys.Contains(kmClipping.Key) &&
                             !targetClippingContents.Contains(kmClipping.Content)) {
-                            if (_clippingRepository.Add(kmClipping)) {
-                                // Keep the dedup sets in sync so a duplicate key/content later
-                                // in the same source file cannot trip the PRIMARY KEY constraint.
-                                targetClippingKeys.Add(kmClipping.Key);
-                                targetClippingContents.Add(kmClipping.Content);
-                            }
+                            clippingCandidates.Add(kmClipping);
+                            // Keep the dedup sets in sync so duplicates later in the same source
+                            // cannot be added twice (the batched INSERT runs in one transaction).
+                            targetClippingKeys.Add(kmClipping.Key);
+                            targetClippingContents.Add(kmClipping.Content);
                         }
                     }
+                    if (clippingCandidates.Count > 0) {
+                        _clippingRepository.Add(clippingCandidates);
+                    }
 
+                    var lineCandidates = new List<OriginalClippingLine>();
                     var targetOriginalKeys = _originalClippingLineRepository.GetAllKeys().ToHashSet();
                     foreach (OriginalClippingLine kmLine in data.OriginalClippingLines) {
                         // Skip orphan lines whose key was removed from clippings by KMate's cleanup.
@@ -77,10 +82,12 @@ namespace KindleMate2.Application.Services.KM2DB {
                             continue;
                         }
                         if (!targetOriginalKeys.Contains(kmLine.Key)) {
-                            if (_originalClippingLineRepository.Add(kmLine)) {
-                                targetOriginalKeys.Add(kmLine.Key);
-                            }
+                            lineCandidates.Add(kmLine);
+                            targetOriginalKeys.Add(kmLine.Key);
                         }
+                    }
+                    if (lineCandidates.Count > 0) {
+                        _originalClippingLineRepository.Add(lineCandidates);
                     }
                 }
 
@@ -90,31 +97,37 @@ namespace KindleMate2.Application.Services.KM2DB {
                         .Select(l => ComposePair(l.WordKey!, l.Timestamp))
                         .ToHashSet();
 
+                    var lookupCandidates = new List<Lookup>();
                     foreach (Lookup kmLookup in data.Lookups) {
                         if (string.IsNullOrWhiteSpace(kmLookup.WordKey)) {
                             continue;
                         }
                         var pair = ComposePair(kmLookup.WordKey, kmLookup.Timestamp);
                         if (!targetLookupPairs.Contains(pair)) {
-                            if (_lookupRepository.Add(kmLookup)) {
-                                targetLookupPairs.Add(pair);
-                            }
+                            lookupCandidates.Add(kmLookup);
+                            targetLookupPairs.Add(pair);
                         }
+                    }
+                    if (lookupCandidates.Count > 0) {
+                        _lookupRepository.Add(lookupCandidates);
                     }
                 }
 
                 if (data.Vocabs.Count > 0) {
                     var targetVocabIds = _vocabRepository.GetAll().Select(v => v.Id).ToHashSet();
 
+                    var vocabCandidates = new List<Vocab>();
                     foreach (Vocab kmVocab in data.Vocabs) {
                         if (string.IsNullOrWhiteSpace(kmVocab.Id)) {
                             continue;
                         }
                         if (!targetVocabIds.Contains(kmVocab.Id)) {
-                            if (_vocabRepository.Add(kmVocab)) {
-                                targetVocabIds.Add(kmVocab.Id);
-                            }
+                            vocabCandidates.Add(kmVocab);
+                            targetVocabIds.Add(kmVocab.Id);
                         }
+                    }
+                    if (vocabCandidates.Count > 0) {
+                        _vocabRepository.Add(vocabCandidates);
                     }
                 }
 

--- a/KindleMate2.Application/Services/KmateDatabaseServiceFactory.cs
+++ b/KindleMate2.Application/Services/KmateDatabaseServiceFactory.cs
@@ -1,0 +1,32 @@
+using KindleMate2.Application.Services.KM2DB;
+using KindleMate2.Domain.Interfaces.KM2DB;
+
+namespace KindleMate2.Application.Services;
+
+/// <inheritdoc cref="IKmateDatabaseServiceFactory"/>
+public class KmateDatabaseServiceFactory : IKmateDatabaseServiceFactory {
+    private readonly IClippingRepository _clippingRepository;
+    private readonly ILookupRepository _lookupRepository;
+    private readonly IOriginalClippingLineRepository _originalClippingLineRepository;
+    private readonly IVocabRepository _vocabRepository;
+
+    public KmateDatabaseServiceFactory(
+        IClippingRepository clippingRepository,
+        ILookupRepository lookupRepository,
+        IOriginalClippingLineRepository originalClippingLineRepository,
+        IVocabRepository vocabRepository) {
+        _clippingRepository = clippingRepository;
+        _lookupRepository = lookupRepository;
+        _originalClippingLineRepository = originalClippingLineRepository;
+        _vocabRepository = vocabRepository;
+    }
+
+    public KmateDatabaseService Create(string km3DbPath) {
+        return new KmateDatabaseService(
+            _clippingRepository,
+            _lookupRepository,
+            _originalClippingLineRepository,
+            _vocabRepository,
+            km3DbPath);
+    }
+}

--- a/KindleMate2.Infrastructure/Repositories/KM2DB/KmateSourceReader.cs
+++ b/KindleMate2.Infrastructure/Repositories/KM2DB/KmateSourceReader.cs
@@ -1,0 +1,209 @@
+using KindleMate2.Domain.Entities.KM2DB;
+using Microsoft.Data.Sqlite;
+
+namespace KindleMate2.Infrastructure.Repositories.KM2DB;
+
+/// <summary>
+/// Read-only mapper for KMate (kmate.io) <c>km3.dat</c> (SQLite). It maps the four tables that share
+/// their lineage with the legacy KM2 format (<c>clippings</c>, <c>original_clipping_lines</c>,
+/// <c>lookups</c>, <c>vocab</c>) onto the KM2 domain entities used by the target repositories.
+/// </summary>
+/// <remarks>
+/// The KMate source schema is NOT identical to the KM2 target schema, so the shared repositories
+/// cannot be pointed at it. Handled differences:
+/// <list type="bullet">
+/// <item>extra source columns (source / note_parent_key / ck_synced / created_at / updated_at / …) are ignored;</item>
+/// <item><c>vocab.id</c> is an INTEGER identity in km3 — a TEXT primary key is derived from <c>word_key</c>
+/// (word_key is unique in practice; rows without a usable key are skipped);</item>
+/// <item>numeric-ish TEXT columns (<c>colorRGB</c>, <c>category</c>, <c>frequency</c>, <c>pagenumber</c>) are
+/// parsed defensively (empty / non-numeric fall back to -1 / 0);</item>
+/// <item>km3 has no <c>settings</c> table and extra tables (<c>books</c>, <c>tags_*</c>, <c>pending_deletions</c>)
+/// are out of scope — they are ignored.</item>
+/// </list>
+/// The source file is opened with <c>Mode=ReadOnly</c> and never written to.
+/// </remarks>
+public static class KmateSourceReader {
+    public sealed record KmateData(
+        List<Clipping> Clippings,
+        List<OriginalClippingLine> OriginalClippingLines,
+        List<Lookup> Lookups,
+        List<Vocab> Vocabs);
+
+    /// <summary>
+    /// Reads a KMate km3.dat into KM2 entity candidates.
+    /// </summary>
+    /// <returns>True when the file exists and at least one of <c>clippings</c>/<c>vocab</c> is present.</returns>
+    public static bool TryRead(string sourcePath, out KmateData data, out string error) {
+        data = null!;
+        error = string.Empty;
+
+        if (!File.Exists(sourcePath)) {
+            error = "KMate database file not found: " + sourcePath;
+            return false;
+        }
+
+        try {
+            using var connection = new SqliteConnection($"Data Source={sourcePath};Mode=ReadOnly;");
+            connection.Open();
+
+            var tables = GetTableNames(connection);
+            if (!tables.Contains("clippings") && !tables.Contains("vocab")) {
+                error = "Not a KMate (km3.dat) database — no clippings/vocab table found.";
+                return false;
+            }
+
+            var clippings = tables.Contains("clippings")
+                ? ReadClippings(connection)
+                : new List<Clipping>();
+            var lines = tables.Contains("original_clipping_lines")
+                ? ReadOriginalClippingLines(connection)
+                : new List<OriginalClippingLine>();
+            var lookups = tables.Contains("lookups")
+                ? ReadLookups(connection)
+                : new List<Lookup>();
+            var vocabs = tables.Contains("vocab")
+                ? ReadVocabs(connection)
+                : new List<Vocab>();
+
+            data = new KmateData(clippings, lines, lookups, vocabs);
+            return true;
+        } catch (Exception e) {
+            error = e.Message;
+            return false;
+        }
+    }
+
+    private static HashSet<string> GetTableNames(SqliteConnection connection) {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT name FROM sqlite_master WHERE type = 'table'";
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            names.Add(reader.GetString(0));
+        }
+        return names;
+    }
+
+    private static List<Clipping> ReadClippings(SqliteConnection connection) {
+        var results = new List<Clipping>();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT key, content, bookname, authorname, brieftype, clippingdate, colorRGB, pagenumber FROM clippings";
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            var key = GetString(reader, 0);
+            if (string.IsNullOrEmpty(key)) {
+                continue;
+            }
+            results.Add(new Clipping {
+                Key = key,
+                Content = GetString(reader, 1) ?? string.Empty,
+                BookName = GetString(reader, 2),
+                AuthorName = GetString(reader, 3),
+                BriefType = reader.IsDBNull(4) ? null : reader.GetInt64(4),
+                ClippingDate = GetString(reader, 5),
+                Read = 0,
+                Sync = 0,
+                ColorRgb = ParseLong(reader, 6, -1),
+                PageNumber = ParseInt(reader, 7, 0)
+            });
+        }
+        return results;
+    }
+
+    private static List<OriginalClippingLine> ReadOriginalClippingLines(SqliteConnection connection) {
+        var results = new List<OriginalClippingLine>();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT key, line1, line2, line3, line4, line5 FROM original_clipping_lines";
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            var key = GetString(reader, 0);
+            if (string.IsNullOrEmpty(key)) {
+                continue;
+            }
+            results.Add(new OriginalClippingLine {
+                Key = key,
+                Line1 = GetString(reader, 1),
+                Line2 = GetString(reader, 2),
+                Line3 = GetString(reader, 3),
+                Line4 = GetString(reader, 4),
+                Line5 = GetString(reader, 5)
+            });
+        }
+        return results;
+    }
+
+    private static List<Lookup> ReadLookups(SqliteConnection connection) {
+        var results = new List<Lookup>();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT word_key, usage, title, authors, timestamp FROM lookups";
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            var wordKey = GetString(reader, 0);
+            if (string.IsNullOrWhiteSpace(wordKey)) {
+                continue;
+            }
+            results.Add(new Lookup {
+                WordKey = wordKey,
+                Usage = GetString(reader, 1),
+                Title = GetString(reader, 2),
+                Authors = GetString(reader, 3),
+                Timestamp = GetString(reader, 4)
+            });
+        }
+        return results;
+    }
+
+    private static List<Vocab> ReadVocabs(SqliteConnection connection) {
+        var results = new List<Vocab>();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT word_key, word, stem, category, translation, timestamp, frequency, colorRGB FROM vocab";
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            var wordKey = GetString(reader, 0);
+            var word = GetString(reader, 1);
+            if (string.IsNullOrWhiteSpace(word)) {
+                continue;
+            }
+            // km3 vocab.id is an INTEGER identity; derive a stable TEXT primary key from word_key.
+            var id = !string.IsNullOrWhiteSpace(wordKey)
+                ? wordKey
+                : word;
+            results.Add(new Vocab {
+                Id = id,
+                WordKey = wordKey,
+                Word = word,
+                Stem = GetString(reader, 2),
+                Category = ParseLong(reader, 3, 0),
+                Translation = GetString(reader, 4),
+                Timestamp = GetString(reader, 5),
+                Frequency = ParseInt(reader, 6, 0),
+                Sync = 0,
+                ColorRgb = ParseLong(reader, 7, -1)
+            });
+        }
+        return results;
+    }
+
+    private static string? GetString(SqliteDataReader reader, int ordinal) {
+        return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+    }
+
+    private static long ParseLong(SqliteDataReader reader, int ordinal, long fallback) {
+        if (reader.IsDBNull(ordinal)) {
+            return fallback;
+        }
+        var raw = Convert.ToString(reader.GetValue(ordinal), System.Globalization.CultureInfo.InvariantCulture);
+        return long.TryParse(raw, out var value) ? value : fallback;
+    }
+
+    private static int ParseInt(SqliteDataReader reader, int ordinal, int fallback) {
+        if (reader.IsDBNull(ordinal)) {
+            return fallback;
+        }
+        var raw = Convert.ToString(reader.GetValue(ordinal), System.Globalization.CultureInfo.InvariantCulture);
+        return int.TryParse(raw, out var value) ? value : fallback;
+    }
+}

--- a/KindleMate2.Infrastructure/Repositories/KM2DB/OriginalClippingLineRepository.cs
+++ b/KindleMate2.Infrastructure/Repositories/KM2DB/OriginalClippingLineRepository.cs
@@ -137,7 +137,7 @@ namespace KindleMate2.Infrastructure.Repositories.KM2DB {
             using var transaction = connection.BeginTransaction();
 
             foreach (OriginalClippingLine originalClippingLine in listOriginalClippings) {
-                var cmd = new SqliteCommand("INSERT INTO original_clipping_lines (key, line1, line2, line3, line4, line5) VALUES (@key, @line1, @line2, @line3, @line4, @line5)", connection);
+                var cmd = new SqliteCommand("INSERT INTO original_clipping_lines (key, line1, line2, line3, line4, line5) VALUES (@key, @line1, @line2, @line3, @line4, @line5)", connection, transaction);
                 cmd.Parameters.AddWithValue("@key", originalClippingLine.Key ?? throw new InvalidOperationException());
                 cmd.Parameters.AddWithValue("@line1", originalClippingLine.Line1 ?? (object)DBNull.Value);
                 cmd.Parameters.AddWithValue("@line2", originalClippingLine.Line2 ?? (object)DBNull.Value);

--- a/KindleMate2.Shared/Strings.Designer.cs
+++ b/KindleMate2.Shared/Strings.Designer.cs
@@ -736,6 +736,33 @@ namespace KindleMate2.Shared {
         }
         
         /// <summary>
+        ///   查找类似 导入KMate数据库 的本地化字符串。
+        /// </summary>
+        public static string Import_KMate_Database {
+            get {
+                return ResourceManager.GetString("Import_KMate_Database", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 导入KMate数据库文件 的本地化字符串。
+        /// </summary>
+        public static string Import_KMate_Database_File {
+            get {
+                return ResourceManager.GetString("Import_KMate_Database_File", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 KMate数据库文件 的本地化字符串。
+        /// </summary>
+        public static string KMate_Database_File {
+            get {
+                return ResourceManager.GetString("KMate_Database_File", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 导入Kindle生词本文件 的本地化字符串。
         /// </summary>
         public static string Import_Kindle_Vocab_File {

--- a/KindleMate2.Shared/Strings.en.resx
+++ b/KindleMate2.Shared/Strings.en.resx
@@ -270,6 +270,15 @@
   <data name="Import_Kindle_Mate_Database_File" xml:space="preserve">
     <value>Import Kindle Mate's Database File</value>
   </data>
+  <data name="Import_KMate_Database" xml:space="preserve">
+    <value>Import KMate Database</value>
+  </data>
+  <data name="Import_KMate_Database_File" xml:space="preserve">
+    <value>Import KMate Database File</value>
+  </data>
+  <data name="KMate_Database_File" xml:space="preserve">
+    <value>KMate Database File</value>
+  </data>
   <data name="Confirm_Delete_Selected_Clippings" xml:space="preserve">
     <value>Are you sure you want to delete the selected clipping(s)?</value>
   </data>

--- a/KindleMate2.Shared/Strings.resx
+++ b/KindleMate2.Shared/Strings.resx
@@ -270,6 +270,15 @@
   <data name="Import_Kindle_Mate_Database_File" xml:space="preserve">
     <value>导入Kindle Mate数据库文件</value>
   </data>
+  <data name="Import_KMate_Database" xml:space="preserve">
+    <value>导入KMate数据库</value>
+  </data>
+  <data name="Import_KMate_Database_File" xml:space="preserve">
+    <value>导入KMate数据库文件</value>
+  </data>
+  <data name="KMate_Database_File" xml:space="preserve">
+    <value>KMate数据库文件</value>
+  </data>
   <data name="Confirm_Delete_Selected_Clippings" xml:space="preserve">
     <value>确认要删除选中的标注吗？</value>
   </data>

--- a/KindleMate2.Shared/Strings.zh-hans.resx
+++ b/KindleMate2.Shared/Strings.zh-hans.resx
@@ -270,6 +270,15 @@
   <data name="Import_Kindle_Mate_Database_File" xml:space="preserve">
     <value>导入Kindle Mate数据库文件</value>
   </data>
+  <data name="Import_KMate_Database" xml:space="preserve">
+    <value>导入KMate数据库</value>
+  </data>
+  <data name="Import_KMate_Database_File" xml:space="preserve">
+    <value>导入KMate数据库文件</value>
+  </data>
+  <data name="KMate_Database_File" xml:space="preserve">
+    <value>KMate数据库文件</value>
+  </data>
   <data name="Confirm_Delete_Selected_Clippings" xml:space="preserve">
     <value>确认要删除选中的标注吗？</value>
   </data>

--- a/KindleMate2.Shared/Strings.zh-hant.resx
+++ b/KindleMate2.Shared/Strings.zh-hant.resx
@@ -270,6 +270,15 @@
   <data name="Import_Kindle_Mate_Database_File" xml:space="preserve">
     <value>導入Kindle Mate數據庫文件</value>
   </data>
+  <data name="Import_KMate_Database" xml:space="preserve">
+    <value>匯入KMate資料庫</value>
+  </data>
+  <data name="Import_KMate_Database_File" xml:space="preserve">
+    <value>匯入KMate資料庫檔案</value>
+  </data>
+  <data name="KMate_Database_File" xml:space="preserve">
+    <value>KMate資料庫檔案</value>
+  </data>
   <data name="Confirm_Delete_Selected_Clippings" xml:space="preserve">
     <value>確認要刪除選中的標註嗎？</value>
   </data>

--- a/KindleMate2.Tests/KmateImportTests.cs
+++ b/KindleMate2.Tests/KmateImportTests.cs
@@ -1,0 +1,158 @@
+using Microsoft.Data.Sqlite;
+using Xunit;
+using KindleMate2.Application.Services.KM2DB;
+using KindleMate2.Infrastructure.Helpers;
+using KindleMate2.Infrastructure.Repositories.KM2DB;
+
+namespace KindleMate2.Tests;
+
+/// <summary>
+/// Tests for importing a KMate (kmate.io) km3.dat database into the current KM2 database
+/// via <see cref="KmateDatabaseService"/> / <see cref="KmateSourceReader"/>.
+/// The km3 source database is synthesized with its real-world schema shape
+/// (extra columns, INTEGER vocab.id, TEXT colorRGB, no settings table).
+/// </summary>
+public sealed class KmateImportTests : IDisposable {
+    private readonly string _dir;
+
+    public KmateImportTests() {
+        _dir = Path.Combine(Path.GetTempPath(), "kmate-import-tests-" + Guid.NewGuid().ToString("N")[..10]);
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose() {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private string NewDb(string name) {
+        var path = Path.Combine(_dir, name);
+        Assert.True(DatabaseHelper.CreateDatabase(path, out var ex), "CreateDatabase failed: " + ex.Message);
+        return path;
+    }
+
+    /// <summary>Creates an empty KMate-shaped km3 database and returns its path.</summary>
+    private string NewKmateDb(string name) {
+        var path = Path.Combine(_dir, name);
+        using (var conn = new SqliteConnection($"Data Source={path};Mode=ReadWriteCreate;")) {
+            conn.Open();
+            foreach (var ddl in KmateSampleDdl) {
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = ddl;
+                cmd.ExecuteNonQuery();
+            }
+        }
+        return path;
+    }
+
+    private static readonly string[] KmateSampleDdl = [
+        """
+        CREATE TABLE clippings (
+            key TEXT PRIMARY KEY, content TEXT, bookname TEXT, authorname TEXT,
+            brieftype INTEGER, clippingdate TEXT, read INT DEFAULT 0, tag TEXT,
+            sync INT DEFAULT 0, newbookname TEXT, colorRGB TEXT DEFAULT '',
+            pagenumber INT DEFAULT 0, source TEXT DEFAULT 'Kindle',
+            note_parent_key TEXT, ck_synced INT DEFAULT 0, created_at TEXT, updated_at TEXT)
+        """,
+        """
+        CREATE TABLE original_clipping_lines (
+            key TEXT PRIMARY KEY, line1 TEXT, line2 TEXT, line3 TEXT, line4 TEXT, line5 TEXT,
+            created_at TEXT, updated_at TEXT)
+        """,
+        """
+        CREATE TABLE lookups (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, word_key TEXT, usage TEXT, title TEXT,
+            authors TEXT, timestamp TEXT, ck_synced INT DEFAULT 0)
+        """,
+        """
+        CREATE TABLE vocab (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, word_key TEXT, word TEXT, stem TEXT,
+            category INTEGER DEFAULT 0, translation TEXT, translation_plain TEXT,
+            dict_source TEXT, timestamp TEXT, frequency INT DEFAULT 0, sync INT DEFAULT 0,
+            ck_synced INT DEFAULT 0, colorRGB TEXT DEFAULT '', last_reviewed TEXT,
+            review_count INT DEFAULT 0, word_level INT DEFAULT 0, created_at TEXT, updated_at TEXT)
+        """,
+        "CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT, author TEXT)",
+        "CREATE TABLE tags_clippings (id INTEGER PRIMARY KEY, name TEXT)",
+        "CREATE TABLE pending_deletions (record_name TEXT PRIMARY KEY, record_type TEXT)"
+    ];
+
+    private static void Execute(SqliteConnection conn, string sql) {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    [Fact]
+    public void ImportKmateDatabase_MapsClippingsLinesLookupsVocab_AndSkipsOrphansAndEmptyContent() {
+        var targetDb = NewDb("kt-target.db");
+        var kmateDb = NewKmateDb("kt-kmate.db");
+
+        using (var conn = new SqliteConnection($"Data Source={kmateDb};Mode=ReadWrite;")) {
+            conn.Open();
+            // Two valid clippings (highlight + note) with matching raw lines…
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, colorRGB, pagenumber, source) VALUES ('a1b2c3d4e5f60718293a4b5c6d7e8f90', 'first highlight', 'Book A', 'Author A', 0, '2026-08-20 10:00:00', '', 12, 'Kindle')");
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, colorRGB, pagenumber, source) VALUES ('b2c3d4e5f60718293a4b5c6d7e8f90a1', 'a note text', 'Book A', 'Author A', 1, '2026-08-20 10:05:00', '', 12, 'Kindle')");
+            // …an empty-content row (skipped by the service)…
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, brieftype, clippingdate, source) VALUES ('c3d4e5f60718293a4b5c6d7e8f90a1b2', '', 'Book A', 0, '2026-08-20 10:10:00', 'Kindle')");
+            // …one orphan line whose key no longer exists in clippings (KMate cleanup residue)…
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('ffffffffffffffffffffffffffffffff', 'orphan line')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1, line2, line3) VALUES ('a1b2c3d4e5f60718293a4b5c6d7e8f90', 'Book A (Author A)', '', 'first highlight')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('b2c3d4e5f60718293a4b5c6d7e8f90a1', 'Book A (Author A)')");
+            // lookups (zh: prefix on word_key) and vocab (INTEGER id identity)
+            Execute(conn, "INSERT INTO lookups (word_key, usage, title, authors, timestamp) VALUES ('zh:测试', 'usage one', 'Book A', 'Author A', '2026-08-20 10:00:00')");
+            Execute(conn, "INSERT INTO lookups (word_key, usage, title, authors, timestamp) VALUES ('en:apple', 'usage two', 'Book A', 'Author A', '2026-08-20 10:01:00')");
+            Execute(conn, "INSERT INTO vocab (word_key, word, stem, category, translation, timestamp, frequency, colorRGB) VALUES ('zh:测试', '测试', '测', 0, 'test', '2026-08-20 10:00:00', 1, '-1')");
+            Execute(conn, "INSERT INTO vocab (word_key, word, stem, category, translation, timestamp, frequency, colorRGB) VALUES ('en:apple', 'apple', 'appl', 0, '', '2026-08-20 10:01:00', 2, '')");
+        }
+
+        var targetClipRepo = new ClippingRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var targetLineRepo = new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var targetLookupRepo = new LookupRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var targetVocabRepo = new VocabRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var svc = new KmateDatabaseService(targetClipRepo, targetLookupRepo, targetLineRepo, targetVocabRepo, kmateDb);
+
+        Assert.True(svc.ImportFromKmateDatabase(), "import should succeed");
+
+        Assert.Equal(2, targetClipRepo.GetAll().Count); // empty-content row skipped
+        Assert.Equal(2, targetLineRepo.GetAllKeys().Count); // orphan line filtered
+        Assert.Equal(2, targetLookupRepo.GetAll().Count);
+        Assert.Equal(2, targetVocabRepo.GetAll().Count);
+
+        // vocab id must be the word_key-derived TEXT id, not the source INTEGER id
+        Assert.NotNull(targetVocabRepo.GetAll().SingleOrDefault(v => v.Id == "zh:测试"));
+        Assert.NotNull(targetVocabRepo.GetAll().SingleOrDefault(v => v.Id == "en:apple"));
+        // colorRGB/category normalization applied
+        var apple = targetVocabRepo.GetAll().Single(v => v.Id == "en:apple");
+        Assert.Equal(-1L, apple.ColorRgb);
+    }
+
+    [Fact]
+    public void ImportKmateDatabase_SecondRun_IsIdempotent() {
+        var targetDb = NewDb("kt-target2.db");
+        var kmateDb = NewKmateDb("kt-kmate2.db");
+
+        using (var conn = new SqliteConnection($"Data Source={kmateDb};Mode=ReadWrite;")) {
+            conn.Open();
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, source) VALUES ('11112222333344445555666677778888', 'same highlight', 'Book X', 'Author X', 0, '2026-08-21 09:00:00', 'Kindle')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('11112222333344445555666677778888', 'Book X (Author X)')");
+            Execute(conn, "INSERT INTO lookups (word_key, usage, title, timestamp) VALUES ('en:word', 'usage', 'Book X', '2026-08-21 09:00:00')");
+            Execute(conn, "INSERT INTO vocab (word_key, word, translation, timestamp, frequency) VALUES ('en:word', 'word', '', '2026-08-21 09:00:00', 1)");
+        }
+
+        var clipRepo = new ClippingRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var lineRepo = new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var lookupRepo = new LookupRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var vocabRepo = new VocabRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var svc = new KmateDatabaseService(clipRepo, lookupRepo, lineRepo, vocabRepo, kmateDb);
+
+        Assert.True(svc.ImportFromKmateDatabase());
+        Assert.Single(clipRepo.GetAll());
+        Assert.Single(vocabRepo.GetAll());
+
+        Assert.True(svc.ImportFromKmateDatabase());
+        Assert.Single(clipRepo.GetAll());
+        Assert.Single(lineRepo.GetAllKeys());
+        Assert.Single(lookupRepo.GetAll());
+        Assert.Single(vocabRepo.GetAll());
+    }
+}

--- a/KindleMate2.Tests/KmateImportTests.cs
+++ b/KindleMate2.Tests/KmateImportTests.cs
@@ -127,6 +127,40 @@ public sealed class KmateImportTests : IDisposable {
     }
 
     [Fact]
+    public void ImportKmateDatabase_CrossBookSameContent_KeepsBothRows() {
+        var targetDb = NewDb("kt-crossbook.db");
+        var kmateDb = NewKmateDb("kt-crossbook-kmate.db");
+
+        using (var conn = new SqliteConnection($"Data Source={kmateDb};Mode=ReadWrite;")) {
+            conn.Open();
+            // Identical sentence highlighted in TWO different books: both are distinct highlights
+            // and must be kept (dedup scope is per book+author+content, not global content).
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, source) VALUES ('aaaa1111222233334444555566667777', 'a shared quote', 'Book A', 'Author A', 0, '2026-08-21 09:00:00', 'Kindle')");
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, source) VALUES ('bbbb1111222233334444555566667777', 'a shared quote', 'Book B', 'Author B', 0, '2026-08-21 09:00:05', 'Kindle')");
+            // …and a genuine duplicate within the SAME book (same key, same content) stays skipped.
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, source) VALUES ('cccc1111222233334444555566667777', 'unique line', 'Book A', 'Author A', 0, '2026-08-21 09:00:10', 'Kindle')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('aaaa1111222233334444555566667777', 'Book A (Author A)')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('bbbb1111222233334444555566667777', 'Book B (Author B)')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('cccc1111222233334444555566667777', 'Book A (Author A)')");
+        }
+
+        var clipRepo = new ClippingRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var lineRepo = new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var svc = new KmateDatabaseService(clipRepo,
+            new LookupRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            lineRepo,
+            new VocabRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            kmateDb);
+
+        Assert.True(svc.ImportFromKmateDatabase());
+        Assert.Equal(3, clipRepo.GetAll().Count); // cross-book same content kept (2) + unique (1)
+        Assert.Equal(3, lineRepo.GetAllKeys().Count);
+
+        Assert.True(svc.ImportFromKmateDatabase()); // idempotent
+        Assert.Equal(3, clipRepo.GetAll().Count);
+    }
+
+    [Fact]
     public void ImportKmateDatabase_SecondRun_IsIdempotent() {
         var targetDb = NewDb("kt-target2.db");
         var kmateDb = NewKmateDb("kt-kmate2.db");

--- a/KindleMate2/FrmMain.Designer.cs
+++ b/KindleMate2/FrmMain.Designer.cs
@@ -43,6 +43,7 @@ namespace KindleMate2 {
             menuImportKindle = new ToolStripMenuItem();
             menuImportKindleWords = new ToolStripMenuItem();
             menuImportKindleMate = new ToolStripMenuItem();
+            menuImportKmateDatabase = new ToolStripMenuItem();
             menuSyncFromKindle = new ToolStripMenuItem();
             menuSyncToKindle = new ToolStripMenuItem();
             menuExportMd = new ToolStripMenuItem();
@@ -186,7 +187,7 @@ namespace KindleMate2 {
             // 
             // menuManage
             // 
-            menuManage.DropDownItems.AddRange(new ToolStripItem[] { menuImportKindle, menuImportKindleWords, menuImportKindleMate, menuSyncFromKindle, menuSyncToKindle, menuExportMd, menuClean, menuRebuild, menuBackup, menuClear });
+            menuManage.DropDownItems.AddRange(new ToolStripItem[] { menuImportKindle, menuImportKindleWords, menuImportKindleMate, menuImportKmateDatabase, menuSyncFromKindle, menuSyncToKindle, menuExportMd, menuClean, menuRebuild, menuBackup, menuClear });
             menuManage.Name = "menuManage";
             menuManage.Size = new Size(107, 36);
             menuManage.Text = "管理(&M)";
@@ -214,6 +215,14 @@ namespace KindleMate2 {
             menuImportKindleMate.Size = new Size(360, 44);
             menuImportKindleMate.Text = "导入Kindle Mate数据库";
             menuImportKindleMate.Click += MenuImportKindleMate_Click;
+            // 
+            // menuImportKmateDatabase
+            // 
+            menuImportKmateDatabase.Image = Resources.page_facing_up;
+            menuImportKmateDatabase.Name = "menuImportKmateDatabase";
+            menuImportKmateDatabase.Size = new Size(360, 44);
+            menuImportKmateDatabase.Text = "导入KMate数据库";
+            menuImportKmateDatabase.Click += MenuImportKmateDatabase_Click;
             // 
             // menuSyncFromKindle
             // 
@@ -1007,6 +1016,7 @@ namespace KindleMate2 {
         private ToolStripMenuItem menuManage;
         private ToolStripMenuItem menuBackup;
         private ToolStripMenuItem menuImportKindleMate;
+        private ToolStripMenuItem menuImportKmateDatabase;
         private ToolStripMenuItem menuSyncFromKindle;
         private ToolStripMenuItem menuImportKindle;
         private ToolStripMenuItem menuRefresh;

--- a/KindleMate2/FrmMain.cs
+++ b/KindleMate2/FrmMain.cs
@@ -198,6 +198,7 @@ namespace KindleMate2 {
             menuImportKindle.Text = Strings.Import_Kindle_Clippings;
             menuImportKindleWords.Text = Strings.Import_Kindle_Vocabs;
             menuImportKindleMate.Text = Strings.Import_Kindle_Mate_Database;
+            menuImportKmateDatabase.Text = Strings.Import_KMate_Database;
             menuSyncFromKindle.Text = Strings.Import_Kindle_Clippings_From_Kindle;
             menuSyncToKindle.Text = Strings.Sync_To_Kindle;
             menuExportMd.Text = Strings.Export_To_Markdown;
@@ -1183,6 +1184,20 @@ namespace KindleMate2 {
 
             RunBackgroundTask(
                 () => _importManager.ImportKmDatabase(fileDialog.FileName),
+                Strings.Successful, Strings.Import_Failed);
+        }
+
+        private void MenuImportKmateDatabase_Click(object sender, EventArgs e) {
+            var fileDialog = new OpenFileDialog {
+                Title = Strings.Import_KMate_Database_File + Strings.Space + @"(km3.dat)",
+                CheckFileExists = true, CheckPathExists = true, DefaultExt = "dat",
+                Filter = Strings.KMate_Database_File + Strings.Space + @"(*.dat)|*.dat",
+                FilterIndex = 2, RestoreDirectory = true, ReadOnlyChecked = true, ShowReadOnly = true
+            };
+            if (fileDialog.ShowDialog() != DialogResult.OK) return;
+
+            RunBackgroundTask(
+                () => _importManager.ImportKmateDatabase(fileDialog.FileName),
                 Strings.Successful, Strings.Import_Failed);
         }
 

--- a/docs/KMate_vs_KindleMate2_分析报告.html
+++ b/docs/KMate_vs_KindleMate2_分析报告.html
@@ -1,0 +1,389 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>KMate 竞品深度分析报告 · 与 KindleMate2 全面对比</title>
+<style>
+  :root{
+    --bg:#101418; --bg2:#161c22; --card:#1a2129; --line:#2b3542;
+    --ink:#e8e2d6; --ink-dim:#a8a293; --ink-faint:#7a7a70;
+    --gold:#c9a35f; --gold-soft:#e0c287; --red:#e08a7a; --green:#8fbf9f; --amber:#d9b36a;
+    --serif:"Source Han Serif SC","Noto Serif SC","Songti SC","STSong","SimSun",Georgia,"Times New Roman",serif;
+  }
+  *{box-sizing:border-box; margin:0; padding:0;}
+  body{background:var(--bg); color:var(--ink); font-family:var(--serif); line-height:1.75; font-size:15px; padding:0 0 80px;}
+  .wrap{max-width:1080px; margin:0 auto; padding:0 32px;}
+  header.hero{padding:72px 0 44px; border-bottom:1px solid var(--line); background:radial-gradient(ellipse at 50% -20%, rgba(201,163,95,.14), transparent 60%);}
+  .kicker{letter-spacing:.35em; color:var(--gold); font-size:12px; text-transform:uppercase; margin-bottom:18px;}
+  h1{font-size:34px; font-weight:600; letter-spacing:.02em; line-height:1.35; margin-bottom:14px;}
+  h1 .sub{display:block; font-size:19px; color:var(--ink-dim); font-weight:400; margin-top:10px;}
+  .meta{color:var(--ink-faint); font-size:13px; margin-top:8px;}
+  .meta b{color:var(--ink-dim); font-weight:600;}
+  h2{font-size:22px; margin:56px 0 8px; color:var(--gold-soft); font-weight:600; letter-spacing:.02em;}
+  h2 .no{color:var(--gold); font-family:Georgia,serif; margin-right:12px; font-size:18px;}
+  .lede{color:var(--ink-dim); font-size:13.5px; border-left:2px solid var(--gold); padding-left:14px; margin-bottom:24px;}
+  h3{font-size:16.5px; margin:28px 0 10px; color:var(--ink); font-weight:600;}
+  p{margin:10px 0; text-align:justify;}
+  .card{background:var(--card); border:1px solid var(--line); border-radius:10px; padding:20px 24px; margin:16px 0;}
+  .grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:12px;}
+  .stat{background:var(--bg2); border:1px solid var(--line); border-radius:8px; padding:14px 16px;}
+  .stat .n{font-size:26px; color:var(--gold-soft); font-family:Georgia,serif; line-height:1.2;}
+  .stat .l{font-size:12.5px; color:var(--ink-faint); margin-top:4px; letter-spacing:.05em;}
+  table{width:100%; border-collapse:collapse; margin:16px 0; font-size:13.5px;}
+  th{background:#1f2731; color:var(--gold-soft); font-weight:600; text-align:left; padding:9px 12px; border:1px solid var(--line); white-space:nowrap;}
+  td{padding:8px 12px; border:1px solid var(--line); vertical-align:top;}
+  tbody tr:nth-child(even){background:rgba(255,255,255,.02);}
+  td.k{white-space:nowrap; color:var(--ink-dim); font-weight:600;}
+  .tag{display:inline-block; font-size:11.5px; padding:1px 9px; border-radius:20px; border:1px solid; margin-right:4px; letter-spacing:.04em; white-space:nowrap;}
+  .tag.lead{color:#6fae87; border-color:#3b6b50; background:rgba(63,148,98,.12);}
+  .tag.par{color:var(--amber); border-color:#6b5833; background:rgba(217,179,106,.10);}
+  .tag.gap{color:#c98a8a; border-color:#7a4545; background:rgba(224,138,122,.10);}
+  .tag.miss{color:#d9a1a1; border-color:#8a4f4f; background:rgba(217,120,120,.14);}
+  .pill{display:inline-block; background:rgba(201,163,95,.12); color:var(--gold-soft); border:1px solid rgba(201,163,95,.4); border-radius:4px; padding:0 8px; font-size:12px; margin-right:6px; letter-spacing:.08em;}
+  .p0{color:#e08a7a; font-weight:700;} .p1{color:var(--gold-soft); font-weight:700;} .p2{color:#8fbf9f; font-weight:700;}
+  ul,ol{margin:8px 0 8px 22px;}
+  li{margin:5px 0;}
+  blockquote{border-left:3px solid var(--gold); background:rgba(201,163,95,.06); padding:12px 18px; margin:16px 0; color:var(--ink-dim); border-radius:0 6px 6px 0;}
+  .src{color:var(--ink-faint); font-size:12px;}
+  .src a{color:var(--gold); text-decoration:none;}
+  .toc{columns:2; column-gap:40px; font-size:14px; margin:10px 0;}
+  .toc a{color:var(--ink-dim); text-decoration:none; display:block; padding:3px 0; border-bottom:1px dashed transparent;}
+  .toc a:hover{color:var(--gold-soft);}
+  footer{margin-top:64px; padding-top:20px; border-top:1px solid var(--line); color:var(--ink-faint); font-size:12.5px;}
+  .hr-gold{height:1px; background:linear-gradient(90deg,transparent,var(--gold),transparent); border:0; margin:36px 0;}
+  .big{font-size:16px;}
+  code{font-family:Consolas,Menlo,monospace; font-size:12.5px; background:rgba(255,255,255,.06); padding:1px 6px; border-radius:4px; color:var(--gold-soft);}
+  @media(max-width:720px){ .toc{columns:1;} .wrap{padding:0 18px;} h1{font-size:26px;} }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="wrap">
+    <div class="kicker">Competitive Intelligence · 竞品深度分析</div>
+    <h1>KMate 深度分析报告
+      <span class="sub">原 Kindle Mate 复活版 · 三端产品 / 定价 / 技术栈全景 &amp; 与 KindleMate2 的差距与机会</span>
+    </h1>
+    <div class="meta">报告日期 <b>2026-09-05</b> · 数据截至 <b>2026-09-04/05</b>(官网 kmate.io + Apple/Microsoft 商店官方 API + 本机安装目录实测)· 分析对象:<b>KMate 3.8.16(桌面)/ 2.3.0(移动)</b> vs <b>KindleMate2(本仓库)</b></div>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <!-- 执行摘要 -->
+  <h2><span class="no">◆</span>执行摘要</h2>
+  <div class="card">
+    <p class="big"><b>KMate 是原“Kindle Mate”在 2026 年的复活重做版</b>(版权 ©2015–2026 KMate Team,开发者署名“军 黄”)。它没有停在 Windows 小工具时代,而是重建成<b>三端产品家族</b>:Windows + macOS 桌面端 + iPhone/iPad 移动端,并引入微信读书、Apple Books 导入与 iCloud 同步,脱离 Kindle 单一生态。</p>
+    <ul>
+      <li><b>定位变了:</b>从“Kindle 标注导出工具”升级为“跨来源阅读知识库(导入→整理→复习→掌握)”。</li>
+      <li><b>商业化了:</b>Windows <b>¥58 一次性买断</b>(15 天完整试用);Mac 免费(限最近 1,000 条)+ Pro <b>终身 ¥168 / 年 ¥68 / 月 ¥12</b>;iOS 免费 + Pro 内购。个人开发者独立运营。</li>
+      <li><b>技术栈意外:</b>Windows 桌面版实测为 <b>Python 3.12 + PyInstaller + mypyc 编译</b>,UI 用 <b>wxPython + WebView2(HTML)渲染</b>——并非 .NET/WPF。</li>
+      <li><b>对你项目的最大含义:</b>KindleMate2 的立身叙事“Kindle Mate 停更后的替代品”<b>已过时</b>;新的差异化空间是 <b>免费开源 + 零门槛 + 轻快原生 + 本地优先</b>,恰好承接 KMate 商业化后流失的免费老用户。</li>
+      <li><b>差距焦点:</b>KMate 领先在词典(含 AI)、闪卡复习、Anki/PDF/Office 导出、标签与阅读模式;KindleMate2 的成熟底盘(解析/去重/Markdown 导出/统计/设备同步)依然扎实,建议按 P0/P1/P2 补短板(见 §6)。</li>
+    </ul>
+  </div>
+
+  <hr class="hr-gold">
+
+  <!-- 目录 -->
+  <h2><span class="no">◆</span>目录</h2>
+  <div class="toc">
+    <a href="#s1">一、KMate 是什么:复活简史与产品画像</a>
+    <a href="#s2">二、三端产品矩阵与商业模式</a>
+    <a href="#s3">三、功能全景</a>
+    <a href="#s4">四、技术栈解剖(安装目录实测)</a>
+    <a href="#s5">五、KindleMate2 现状快照</a>
+    <a href="#s6">六、功能对比矩阵</a>
+    <a href="#s7">七、差距、机会与 P0/P1/P2 路线</a>
+    <a href="#s8">八、结论</a>
+    <a href="#s9">附录:信息来源与说明</a>
+  </div>
+
+  <hr class="hr-gold">
+
+  <!-- 一 -->
+  <h2 id="s1"><span class="no">01</span>KMate 是什么:复活简史与产品画像</h2>
+  <p class="lede">一句话:它回来了,而且不再只是“Kindle 伴侣”。</p>
+
+  <h3>1.1 沿革</h3>
+  <p>Kindle Mate 是一款服务 Kindle 读者 10 年以上的标注/生词管理工具(版权信息 <b>©2015–2026 KMate Team</b>,官网与商店署名开发者“军 黄”,bundle id <code>io.kmate.kindlemate</code>)。它曾长期停更,KindleMate2 仓库正是当年为“停更后的替代”而生(README 原文)。2026 年 8 月,它以 <b>KMate</b> 品牌回归:新官网 kmate.io、Windows 上架 Microsoft Store、新增 macOS 与 iOS 端,版本推进到 <b>桌面 v3.8.16</b>。</p>
+
+  <h3>1.2 官方自述定位</h3>
+  <blockquote>“把每一次摘录与查词,变成真正留下的知识。KMate 把 Kindle 标注、笔记与生词汇集到一个专注的工作空间:桌面端深度整理与阅读,iPhone 与 iPad 随时复习回顾。”<br>
+  <span class="src">—— kmate.io/zh 首页标语“让每次阅读,都有回响”</span></blockquote>
+
+  <h3>1.3 关键数字(官网口径)</h3>
+  <div class="grid">
+    <div class="stat"><div class="n">10+ 年</div><div class="l">持续服务 Kindle 读者</div></div>
+    <div class="stat"><div class="n">100,000+</div><div class="l">海量内容流畅管理</div></div>
+    <div class="stat"><div class="n">13</div><div class="l">覆盖所有 Kindle 标注语言解析</div></div>
+    <div class="stat"><div class="n">0</div><div class="l">App 收集的数据</div></div>
+    <div class="stat"><div class="n">7</div><div class="l">界面语言(简中/繁中/英/日/德/法/波兰)</div></div>
+  </div>
+
+  <hr class="hr-gold">
+
+  <!-- 二 -->
+  <h2 id="s2"><span class="no">02</span>三端产品矩阵与商业模式</h2>
+  <p class="lede">每个平台独立版本号、独立商店、独立免费/付费策略——这是理解 KMate 的关键。</p>
+
+  <table>
+    <thead><tr><th>维度</th><th>Windows(桌面)</th><th>macOS(桌面)</th><th>iPhone / iPad(移动)</th></tr></thead>
+    <tbody>
+      <tr><td class="k">商店名称</td><td>KMate: Kindle标注笔记与生词本管理工具</td><td>KMate: 标注笔记与生词本管理助手</td><td>KMate: 标注笔记生词本学习</td></tr>
+      <tr><td class="k">版本(截至 9/4)</td><td><b>3.8.16</b>(2026-08-21 更新)</td><td><b>3.8.16</b>(2026-08-20 发布)</td><td><b>2.3.0</b>(2026-08-20 发布)</td></tr>
+      <tr><td class="k">最低系统</td><td>Windows 10 / 11(商店包要求 ≥1809)</td><td>macOS 10.13+(Intel 与 Apple Silicon)</td><td>iOS / iPadOS 17.0+</td></tr>
+      <tr><td class="k">包体积</td><td>安装目录约 350 MB(含 Python 运行时)</td><td>约 64 MB(Mac App Store)</td><td>约 12 MB(App Store)</td></tr>
+      <tr><td class="k">定价模式</td><td><b>¥58 一次性买断</b>,完整 Pro 功能 + <b>15 天免费试用</b>,无订阅</td><td>免费下载(全功能但<b>仅显示最近 1,000 条</b>);Pro 内购:<b>终身 ¥168 / 年 ¥68 / 月 ¥12</b></td><td>免费(含 Kindle/Amazon 导入、无限浏览与闪卡、TXT/Anki 导出);Pro 解锁高级主题/字体、Markdown/PDF 导出、打印、无限统计</td></tr>
+      <tr><td class="k">商店评分</td><td>暂无(新上架)</td><td>暂无(新上架)</td><td>5.0(仅 1 条,新上架)</td></tr>
+      <tr><td class="k">同步方式</td><td>本机数据库 → 手动导入 KMate Mobile</td><td colspan="2">个人 iCloud 自动同步(免费,iOS 用 Mac 时同步免费)</td></tr>
+    </tbody>
+  </table>
+  <p class="src">价格来源:Microsoft Store 产品 API(¥58.00,SKU 0010 full)+ App Store 中国大陆区页面(¥168/¥68/¥12);均为 2026-09-04 抓取。iOS 端内购具体金额以商店页为准(未单独核实)。</p>
+
+  <h3>2.1 商业模式解读</h3>
+  <ul>
+    <li><b>“免费试用/免费额度 + 解锁”双轨:</b>Windows 用“15 天完整试用 + 买断”;Apple 生态用“永久免费额度(1,000 条)”制造升级动机——额度限制比功能限制更“钝感”,不易劝退,但长期使用必触发付费。</li>
+    <li><b>iCloud 作为锁定层:</b>Mac/iOS 用户数据进入个人 iCloud,迁移成本随数据量上升而上升。</li>
+    <li><b>个人开发者</b>(“军 黄”,非公司主体):意味着无融资压力、更新节奏自主;同时意味着售后、长期维护与跨平台质量存在个人产能上限。</li>
+  </ul>
+
+  <hr class="hr-gold">
+
+  <!-- 三 -->
+  <h2 id="s3"><span class="no">03</span>功能全景</h2>
+  <p class="lede">按“导入 → 整理 → 词典 → 复习 → 统计 → 阅读 → 导出 → 同步/隐私”八条线展开。</p>
+
+  <h3>3.1 导入源(横向扩张是这轮更新的主轴)</h3>
+  <ul>
+    <li><b>Kindle 全系设备</b>(Paperwhite / Colorsoft / Scribe / Touch / Voyage / Oasis 等):自动识别、一键导入标注、笔记与生词本,含 Kindle 占用冲突提示。</li>
+    <li><b>Kindle App 与 Amazon Kindle 云端</b>、<b>微信读书</b>(多端笔记)桌面导入。</li>
+    <li><b>Apple Books</b>(仅 Mac,v3.8 新增):保留书名、作者、颜色标记与来源,可在数据库/阅读模式按来源独立管理。</li>
+    <li>旧 <b>KMate / KM2 数据库</b>整库导入(继承老用户)。</li>
+    <li>解析能力:13 种语言标注;重复标注自动清理(含 Kindle Scribe 场景)。</li>
+  </ul>
+
+  <h3>3.2 整理</h3>
+  <ul>
+    <li>智能去重合并(多端合并同一本书);按 <b>Kindle / 微信读书 / Apple Books / KMate 来源分组</b>。</li>
+    <li>分组维度:名称、作者、书籍语言、日历、学习状态;标签、颜色、多语言排序。</li>
+    <li>书名/作者<b>双击编辑 + 名称映射</b>:改名后后续导入与 iCloud 同步自动沿用(避免旧名复现)。</li>
+    <li>全文与通配符搜索(面向大型资料库,10 万+ 内容)。</li>
+  </ul>
+
+  <h3>3.3 词典与查词(差异化最重的一块)</h3>
+  <ul>
+    <li><b>本地词典:</b>桌面端 StarDict(.tar.gz)、MDict(.mdx/.mdd)、MOBI/PRC、三列 TSV、纯文本;移动端另支持 AZW。</li>
+    <li><b>在线释义:</b>Google 翻译、Bing 翻译、金山词霸在线、DeepL / FreeDictionary API。</li>
+    <li><b>AI 查词:</b>Gemini / DeepSeek——生词条目可并列本地 + 在线 + AI 释义。</li>
+    <li>生词来源:Kindle Vocabulary Builder,保留原始用法例句与词频。</li>
+  </ul>
+
+  <h3>3.4 复习 / 学习</h3>
+  <ul>
+    <li>卡片或列表阅读;随机与渐进式<b>闪卡复习</b>(移动端优化了卡片布局:用法/释义分栏显示、切换动画)。</li>
+    <li>学习状态管理 + 活动趋势(日历热力图,按日/月/年;可直接按日期筛内容)。</li>
+    <li>统计洞察覆盖标注、生词、掌握度、书籍层面;移动端 Pro 含“无限统计洞察”。</li>
+  </ul>
+
+  <h3>3.5 阅读模式</h3>
+  <ul>
+    <li>数据库整理 ↔ <b>阅读模式</b>(快捷键 Ctrl+R):卡片 / 列表 / 文章视图,书籍封面、护眼主题、字体、自动折叠、快捷编辑。</li>
+    <li>文章视图内嵌 Markdown 笔记、关联标注、独立书籍笔记;支持打印与卡片导出。</li>
+  </ul>
+
+  <h3>3.6 导出</h3>
+  <ul>
+    <li>Markdown / PDF / Word / Excel / CSV / TXT;桌面 + 移动覆盖面不同(Mac/iOS 的 Markdown/PDF 属 Pro)。</li>
+    <li><b>Anki 导出</b>(v3.8 更新):支持正反面字段、卡片风格、原始 HTML 或精简释义。</li>
+  </ul>
+
+  <h3>3.7 同步与隐私</h3>
+  <ul>
+    <li>数据库默认存本机;Mac ↔ iOS 用<b>个人 iCloud</b>(免费);Windows 通过数据库文件移交到移动端。</li>
+    <li>隐私口径:“App 收集的数据 = 0”;Amazon 导入按需读取;在线词典仅发送当前查询词。</li>
+  </ul>
+
+  <hr class="hr-gold">
+
+  <!-- 四 -->
+  <h2 id="s4"><span class="no">04</span>技术栈解剖(安装目录实测)</h2>
+  <p class="lede">基于用户本机安装目录 <code>C:\Program Files\WindowsApps\KMateTeam.KMate-KindleClippingsVocabulary_3.8.16.0_neutral__nmhyc6rsazbye</code> 的文件级观察(2026-09-05)。</p>
+
+  <h3>4.1 一句话结论</h3>
+  <p><b>Windows 桌面版不是 .NET 程序,而是 Python 3.12 + PyInstaller 打包的桌面应用</b>,核心业务用 mypyc 编译成原生扩展保护,UI 走“wxPython 外壳 + WebView2 渲染 HTML 视图”的混合架构。</p>
+
+  <table>
+    <thead><tr><th>层</th><th>技术</th><th>证据(安装目录)</th><th>解读</th></tr></thead>
+    <tbody>
+      <tr><td class="k">分发</td><td>MSIX(微软商店)</td><td>AppxManifest.xml:Windows.Desktop、runFullTrust、ProcessorArchitecture=neutral</td><td>全信任 Win32 打包(非 UWP);7 语言资源</td></tr>
+      <tr><td class="k">运行时</td><td>Python 3.12</td><td>python312.dll、base_library.zip、_internal 结构</td><td>PyInstaller onedir 模式</td></tr>
+      <tr><td class="k">核心逻辑</td><td>mypyc 编译</td><td>81d243bd…__mypyc.cp312-win_amd64.pyd</td><td>业务代码编译为原生 .pyd:性能 + 反逆向</td></tr>
+      <tr><td class="k">UI 框架</td><td>wxPython 4.x</td><td>_internal/wx:wxmsw32u_core/webview/richtext/html/dataview + svg</td><td>原生窗口外壳</td></tr>
+      <tr><td class="k">渲染层</td><td>WebView2(Edge)</td><td>WebView2Loader.dll、wxmsw32u_webview、modules/**/templates+static(HTML)</td><td>阅读/详情/统计等用 HTML+CSS+JS 渲染(带 Jinja2 风格模板)</td></tr>
+      <tr><td class="k">存储</td><td>SQLite</td><td>_sqlite3.pyd + sqlite3.dll</td><td>本地库</td></tr>
+      <tr><td class="k">设备连接</td><td>WinRT + libusb</td><td>winsdk/_winrt.pyd、libusb-1.0.dll</td><td>Kindle MTP/USB 识别同步</td></tr>
+      <tr><td class="k">词典引擎</td><td>自研 mdx 插件</td><td>modules/dict_management/mdx_plugin/minilzo.dll</td><td>MDict 解压算法(minilzo)内嵌</td></tr>
+      <tr><td class="k">辅助库</td><td>lxml / numpy / PIL</td><td>lxml、numpy-2.4.4、PIL 目录</td><td>解析 / 数据处理 / 封面图像</td></tr>
+      <tr><td class="k">网络</td><td>OpenSSL + requests 系</td><td>libssl-3/libcrypto-3、certifi、charset_normalizer、dateutil</td><td>在线词典 / AI / Amazon 云端</td></tr>
+    </tbody>
+  </table>
+
+  <h3>4.2 业务模块划分(由打包目录反推)</h3>
+  <div class="card">
+    <p style="margin:0"><span class="pill">modules/note_view</span><span class="pill">modules/vocab_view</span><span class="pill">modules/reading_mode_note</span><span class="pill">modules/dict_management</span><span class="pill">modules/detail_view</span><span class="pill">note_markdown.css/js</span></p>
+    <p style="margin:8px 0 0; font-size:13px" class="src">标注视图(详情/空态/新建书籍/阅读模式 HTML)、生词视图、阅读模式 + global_stats 统计页、词典管理(MDX 插件)、详情静态资源——代码按“视图”垂直切片,与官网“数据库模式 / 阅读模式”双模式呼应。</p>
+  </div>
+
+  <h3>4.3 对 KindleMate2 的三点启示</h3>
+  <ol>
+    <li><b>阅读/详情视图 = 桌面壳 + WebView2 HTML</b> 是省力路径:WinForms/WPF 嵌 WebView2 完全同构,不必等 WPF 重写即可获得排版/护眼主题能力。</li>
+    <li><b>MDict 接入的门槛就是 minilzo</b>:KMate 证明了“桌面端自己做 mdx 解压”可行且代码量可控。</li>
+    <li><b>“Python + Chromium”是它的重量包袱</b>(数百 MB、启动慢、内存高);KindleMate2 的 .NET 8 原生 WinForms“轻、快、免运行时”是实打实的差异化卖点,README 定位更新时应正面利用。</li>
+  </ol>
+
+  <hr class="hr-gold">
+
+  <!-- 五 -->
+  <h2 id="s5"><span class="no">05</span>KindleMate2 现状快照</h2>
+  <p class="lede">来自本仓库源码盘点(README + 分层项目结构 + 关键类梳理,2026-09-04)。</p>
+  <div class="grid">
+    <div class="stat"><div class="n">.NET 8</div><div class="l">WinForms · x86/x64/ARM64</div></div>
+    <div class="stat"><div class="n">SQLite</div><div class="l">KM2.dat · clippings/lookups/vocab 等表</div></div>
+    <div class="stat"><div class="n">Win7+</div><div class="l">兼容下限(推荐 Win11)</div></div>
+    <div class="stat"><div class="n">MIT</div><div class="l">开源 · GitHub lzcapp/KindleMate2</div></div>
+  </div>
+  <table>
+    <thead><tr><th>能力面</th><th>状态</th><th>说明</th></tr></thead>
+    <tbody>
+      <tr><td class="k">导入解析</td><td><span class="tag lead">成熟</span></td><td>My Clippings.txt(Highlight/Note/Bookmark/Cut、中英多语言日期页号)、Kindle vocab.db、旧 KM2.dat</td></tr>
+      <tr><td class="k">去重</td><td><span class="tag lead">成熟</span></td><td>复合键(时间+位置)+ 内容包含去重、原子回滚;单测覆盖 5000/3000 行批量场景</td></tr>
+      <tr><td class="k">分组/浏览</td><td><span class="tag lead">成熟</span></td><td>按书/按词 TreeView;书名/作者批量重命名;状态栏计数</td></tr>
+      <tr><td class="k">搜索</td><td><span class="tag par">部分</span></td><td>SQL LIKE + 类型过滤 + 自动补全;无 FTS、无标签(tag 列仅残留)</td></tr>
+      <tr><td class="k">导出</td><td><span class="tag par">部分</span></td><td>Markdown + HTML(带 TOC)较完整;无 Anki/PDF/Word/Excel/CSV</td></tr>
+      <tr><td class="k">词典/查词</td><td><span class="tag miss">缺失</span></td><td>无(DictInfo 仅为 Kindle 内部词典元数据)</td></tr>
+      <tr><td class="k">复习/闪卡</td><td><span class="tag miss">缺失</span></td><td>read/sync/colorRGB 列是旧版遗留骨架</td></tr>
+      <tr><td class="k">统计</td><td><span class="tag lead">较完整</span></td><td>FrmStatistics:标注/生词按日、时、星期 6 图 + 摘要,可存 PNG</td></tr>
+      <tr><td class="k">阅读模式</td><td><span class="tag miss">缺失</span></td><td>仅底部 RichTextBox 详情面板</td></tr>
+      <tr><td class="k">设备同步</td><td><span class="tag lead">成熟</span></td><td>Kindle MTP/USB 双向文件同步(DeviceManager)</td></tr>
+      <tr><td class="k">主题/语言</td><td><span class="tag lead">成熟</span></td><td>DarkModeForms 深色主题、明暗 MessageBox;中/英/繁</td></tr>
+      <tr><td class="k">测试</td><td><span class="tag par">窄而实</span></td><td>xUnit 数据层回归(批量插入/去重/删除/导入)</td></tr>
+      <tr><td class="k">其他</td><td><span class="tag par">进行中</span></td><td>分层重构(.NET 8, Application/Domain/Infrastructure);WPF 计划未落地(无源码);Updater 已接 AutoUpdaterDotNET</td></tr>
+    </tbody>
+  </table>
+
+  <hr class="hr-gold">
+
+  <!-- 六 -->
+  <h2 id="s6"><span class="no">06</span>功能对比矩阵</h2>
+  <p class="lede">逐功能点对齐;标签含义:<span class="tag lead">领先</span><span class="tag par">相当/部分</span><span class="tag gap">落后</span><span class="tag miss">缺失</span>(以 KindleMate2 视角)。</p>
+
+  <table>
+    <thead><tr><th style="width:13%">功能域</th><th style="width:38%">KMate 3.8.16(商业)</th><th style="width:38%">KindleMate2(开源)</th><th>判定</th></tr></thead>
+    <tbody>
+      <tr><td class="k">导入源</td><td>Kindle 设备/App/云端、微信读书、Apple Books(Mac)、旧 KM 库</td><td>My Clippings.txt、vocab.db、旧 KM2.dat</td><td><span class="tag gap">落后</span></td></tr>
+      <tr><td class="k">标注解析</td><td>13 种语言、Scribe 去重清理</td><td>中英多语言、页号/日期、Bookmark/Cut 全类型</td><td><span class="tag par">相当</span></td></tr>
+      <tr><td class="k">去重</td><td>智能去重 + 多端合并</td><td>复合键 + 内容包含去重(单测覆盖)</td><td><span class="tag par">相当</span></td></tr>
+      <tr><td class="k">来源分组</td><td>Kindle/微信/Apple Books/KMate 分组 + 来源图标</td><td>按书/按词 TreeView</td><td><span class="tag par">相当</span></td></tr>
+      <tr><td class="k">标签/颜色</td><td>标签、颜色、状态、多语言排序</td><td>无(tag/colorRGB 遗留)</td><td><span class="tag miss">缺失</span></td></tr>
+      <tr><td class="k">搜索</td><td>全文 + 通配符(FTS 级)</td><td>LIKE 模糊 + 类型过滤</td><td><span class="tag gap">落后</span></td></tr>
+      <tr><td class="k">书目管理</td><td>双击改名 + 名称映射自动沿用</td><td>批量重命名</td><td><span class="tag gap">落后</span></td></tr>
+      <tr><td class="k">词典</td><td>MDict/StarDict/MOBI/TSV/文本 + 在线 + Gemini/DeepSeek AI</td><td>无</td><td><span class="tag miss">缺失</span></td></tr>
+      <tr><td class="k">生词例句/词频</td><td>Vocabulary Builder 全量 + lookup 聚合</td><td>lookup 例句聚合、加粗高亮</td><td><span class="tag par">相当</span></td></tr>
+      <tr><td class="k">复习/闪卡</td><td>卡片/列表 + 渐进闪卡 + 学习状态</td><td>无</td><td><span class="tag miss">缺失</span></td></tr>
+      <tr><td class="k">统计洞察</td><td>日历热力图(日/月/年)+ 多维趋势</td><td>日/时/星期分布 6 图 + 摘要</td><td><span class="tag par">相当</span></td></tr>
+      <tr><td class="k">阅读模式</td><td>卡片/列表/文章视图 + 封面/护眼/字体</td><td>无</td><td><span class="tag miss">缺失</span></td></tr>
+      <tr><td class="k">Markdown 导出</td><td>有(含自定义)</td><td>有(TOC + styles.css)</td><td><span class="tag par">相当</span></td></tr>
+      <tr><td class="k">Anki/PDF/Office/CSV</td><td>Anki(正反字段/HTML)、PDF、Word、Excel、CSV、TXT</td><td>无</td><td><span class="tag miss">缺失</span></td></tr>
+      <tr><td class="k">设备同步</td><td>Kindle 授权/识别/占用提示</td><td>Kindle MTP/USB 双向</td><td><span class="tag par">相当</span></td></tr>
+      <tr><td class="k">云同步</td><td>iCloud(Mac+iOS)/ 库移交(Windows→移动)</td><td>无(纯本机)</td><td><span class="tag gap">落后</span></td></tr>
+      <tr><td class="k">平台覆盖</td><td>Windows / macOS / iOS / iPadOS</td><td>仅 Windows(Win7+)</td><td><span class="tag gap">落后</span></td></tr>
+      <tr><td class="k">深色主题/多语言</td><td>护眼主题 + 7 语言</td><td>DarkModeForms + 中英繁</td><td><span class="tag par">相当</span></td></tr>
+      <tr><td class="k">商业模式</td><td>试用/额度 + 买断或订阅(收费)</td><td>MIT 免费开源</td><td><span class="tag lead">领先</span></td></tr>
+      <tr><td class="k">性能/体积</td><td>Python + Chromium,数百 MB</td><td>.NET 原生,轻快免运行时</td><td><span class="tag lead">领先</span></td></tr>
+    </tbody>
+  </table>
+
+  <hr class="hr-gold">
+
+  <!-- 七 -->
+  <h2 id="s7"><span class="no">07</span>差距、机会与 P0/P1/P2 路线</h2>
+  <p class="lede">先谈战略(定位被“复活”这件事改写),再谈功能补短板。</p>
+
+  <h3>7.1 战略层:KindleMate2 的叙事必须更新</h3>
+  <blockquote>
+    README 现状写的是 “Kindle Mate 停止更新后提供的替代方案”(2023 年视角)。<b>2026 年 KMate 复活了</b>,这句已过时,而且继续写会显得项目“跟着别人节奏走”。
+  </blockquote>
+  <ul>
+    <li><b>新定位建议:</b>“免费、开源、无试用限制的 Kindle 标注管理工具——KMate/同类商业软件的轻快替代”。承接的正是 KMate 商业化(¥58 买断 / ¥168 终身)后不愿付费的存量用户。</li>
+    <li><b>命名风险提示:</b>KMate 商标与品牌已复归活跃,KindleMate2 与 “Kindle Mate” 高度相近;建议在 README 明示“与 KMate(kmate.io)/ Amazon 无关联”,避免混淆与商标纠纷隐患。</li>
+    <li><b>护城河:</b>MIT 开源 + 本地优先(零遥测)+ 原生轻快 + Windows 7–11 广兼容。KMate 的 Python+WebView2 栈决定了它“重”;你的 .NET 原生栈是结构性优势,应在 README/首页强调。</li>
+  </ul>
+
+  <h3>7.2 P0 —— 基本盘(低成本、高感知)</h3>
+  <ol>
+    <li><span class="p0">P0 · 更新 README 定位表述</span>:删除“停更替代”过时叙事,改为上述新定位,并加“与 KMate 无关联”声明。</li>
+    <li><span class="p0">P0 · 补 CSV / Excel 导出</span>:办公与数据迁移高频格式;基于现有 Markdown 导出管线扩展,工作量小、对标缺口立减。</li>
+    <li><span class="p0">P0 · CSV 通用导入(可选)</span>:让用户能把 KMate/其他工具导出的 CSV 拉进来,直接降低“从 KMate 迁移到 KindleMate2”的换血成本——这是承接竞品流失用户的关键钩子。</li>
+  </ol>
+
+  <h3>7.3 P1 —— 体验补强(中等投入)</h3>
+  <ol>
+    <li><span class="p1">P1 · 标签与 SQLite FTS5 全文搜索</span>:tag 列已存在,补 UI 即可;LIKE → FTS5 是 SQLite 原生能力,查询体验质变。</li>
+    <li><span class="p1">P1 · 阅读/详情视图(WebView2 路线)</span>:用 WinForms 内嵌 WebView2 渲染 Markdown 阅读模式——KMate 已证明此架构可行,不必等 WPF。</li>
+    <li><span class="p1">P1 · 在线释义接入</span>:哪怕先接 1 个免费源(如有道/FreeDictionary),生词详情立即“活”起来;后续再考虑 MDict(minilzo 算法已明确)。</li>
+  </ol>
+
+  <h3>7.4 P2 —— 重投入,建议观望/不做</h3>
+  <ol>
+    <li><span class="p2">闪卡/复习与 Anki 导出</span>:Anki 生态自带工具;可引导用户走 CSV→Anki 导入,先不做原生闪卡。</li>
+    <li><span class="p2">移动端 / 云同步</span>:与 iCloud 生态的正面竞争投入产出比低;守住“Windows 桌面最佳”即可。</li>
+    <li><span class="p2">WPF 重写</span>:README 已划线搁置;除非学习目的,不建议重启。</li>
+  </ol>
+
+  <hr class="hr-gold">
+
+  <!-- 八 -->
+  <h2 id="s8"><span class="no">08</span>结论</h2>
+  <div class="card">
+    <p class="big">KMate 的复活对 KindleMate2 不是“敌人回来了”,而是<b>“你当初存在的理由变了,但新的理由更清晰了”</b>。</p>
+    <p style="margin-bottom:6px">KMate 选择了一条“重而全”的路线(跨平台 + 多来源 + AI + 订阅/买断);KindleMate2 的合理身位是<b>“轻而诚”</b>:</p>
+    <ul>
+      <li><b>诚实</b>:免费开源、本机存储、零遥测,把“不收集数据”从口号变成代码事实;</li>
+      <li><b>轻快</b>:原生 .NET、秒开、无 Chromium 负担,兼容 Windows 7–11;</li>
+      <li><b>会补课</b>:按 P0/P1 补齐导出格式、标签/FTS、阅读视图与在线释义,把“够用”推进到“好用”,同时专注服务好愿意留在桌面的深度用户。</li>
+    </ul>
+    <p style="margin-top:10px" class="src">一句话给维护者:改 README → 补导出 → 接 WebView2 阅读视图 → 用“免费/轻快/本地优先”正面承接 KMate 商业化后的市场缝隙。</p>
+  </div>
+
+  <hr class="hr-gold">
+
+  <!-- 附录 -->
+  <h2 id="s9"><span class="no">09</span>附录:信息来源与说明</h2>
+  <h3>9.1 信息源与采集时间</h3>
+  <table>
+    <thead><tr><th>来源</th><th>内容</th><th>时间</th></tr></thead>
+    <tbody>
+      <tr><td class="k">kmate.io/zh(官网)</td><td>产品定位、三端介绍、更新日志入口、10+年/100,000+/13 语言/0 数据</td><td>2026-09-04</td></tr>
+      <tr><td class="k">Microsoft Store 产品 API(storeedgefd)</td><td>Windows 版 ¥58.00 买断、15 天试用、SKU/包名、更新 2026-08-21、功能长描述、系统要求</td><td>2026-09-05</td></tr>
+      <tr><td class="k">App Store Lookup API(CN)</td><td>Mac/iOS 版本、发布日期、体积、最低系统、更新日志全文</td><td>2026-09-05</td></tr>
+      <tr><td class="k">App Store CN 页面(搜索缓存)</td><td>Mac Pro 内购:终身 ¥168 / 年 ¥68 / 月 ¥12;FAQ 全文(免费/Pro 差异、词典格式、系统要求、隐私)</td><td>2026-09-04</td></tr>
+      <tr><td class="k">本机安装目录实测</td><td>技术栈(§4):文件级观察,未执行程序、未反编译、未复制任何代码</td><td>2026-09-05</td></tr>
+      <tr><td class="k">本仓库源码盘点</td><td>KindleMate2 现状(§5):README + 分层项目结构 + 关键类梳理</td><td>2026-09-04</td></tr>
+    </tbody>
+  </table>
+  <h3>9.2 局限与声明</h3>
+  <ul>
+    <li>官网子页(whatsnew/features)有浏览器反爬,细节以商店页更新日志与 FAQ 为准;iOS 端 Pro 内购金额未单独核实,以商店为准。</li>
+    <li>商店评分均为新上架初值(Mac/Win 暂无、iOS 5.0×1),不代表长期口碑。</li>
+    <li>技术栈判断基于打包目录文件名与结构,属静态观察;不构成对 KMate 内部实现的完整断言。</li>
+    <li>本报告仅作产品与工程对标参考,不涉及对第三方软件的代码复制或再分发。</li>
+  </ul>
+
+  <footer>
+    KindleMate2 仓库内部报告 · 由 WorkBuddy 于 2026-09-05 生成 · 供产品决策与开发排期参考
+  </footer>
+</div>
+</body>
+</html>

--- a/docs/KMate_技术侦察报告.html
+++ b/docs/KMate_技术侦察报告.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>KMate 技术侦察报告 · 安装技术栈与数据格式详解</title>
+<style>
+  :root{
+    --bg:#101418; --bg2:#161c22; --card:#1a2129; --line:#2b3542;
+    --ink:#e8e2d6; --ink-dim:#a8a293; --ink-faint:#7a7a70;
+    --gold:#c9a35f; --gold-soft:#e0c287; --green:#8fbf9f; --amber:#d9b36a;
+    --serif:"Source Han Serif SC","Noto Serif SC","Songti SC","STSong","SimSun",Georgia,"Times New Roman",serif;
+  }
+  *{box-sizing:border-box; margin:0; padding:0;}
+  body{background:var(--bg); color:var(--ink); font-family:var(--serif); line-height:1.75; font-size:15px; padding:0 0 80px;}
+  .wrap{max-width:1080px; margin:0 auto; padding:0 32px;}
+  header.hero{padding:72px 0 44px; border-bottom:1px solid var(--line); background:radial-gradient(ellipse at 50% -20%, rgba(201,163,95,.14), transparent 60%);}
+  .kicker{letter-spacing:.35em; color:var(--gold); font-size:12px; text-transform:uppercase; margin-bottom:18px;}
+  h1{font-size:34px; font-weight:600; letter-spacing:.02em; line-height:1.35; margin-bottom:14px;}
+  h1 .sub{display:block; font-size:19px; color:var(--ink-dim); font-weight:400; margin-top:10px;}
+  .meta{color:var(--ink-faint); font-size:13px; margin-top:8px;}
+  .meta b{color:var(--ink-dim); font-weight:600;}
+  h2{font-size:22px; margin:56px 0 8px; color:var(--gold-soft); font-weight:600; letter-spacing:.02em;}
+  h2 .no{color:var(--gold); font-family:Georgia,serif; margin-right:12px; font-size:18px;}
+  .lede{color:var(--ink-dim); font-size:13.5px; border-left:2px solid var(--gold); padding-left:14px; margin-bottom:24px;}
+  h3{font-size:16.5px; margin:28px 0 10px; color:var(--ink); font-weight:600;}
+  p{margin:10px 0; text-align:justify;}
+  .card{background:var(--card); border:1px solid var(--line); border-radius:10px; padding:20px 24px; margin:16px 0;}
+  .grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:12px;}
+  .stat{background:var(--bg2); border:1px solid var(--line); border-radius:8px; padding:14px 16px;}
+  .stat .n{font-size:22px; color:var(--gold-soft); font-family:Georgia,serif; line-height:1.2;}
+  .stat .l{font-size:12px; color:var(--ink-faint); margin-top:4px; letter-spacing:.03em;}
+  table{width:100%; border-collapse:collapse; margin:16px 0; font-size:13px;}
+  th{background:#1f2731; color:var(--gold-soft); font-weight:600; text-align:left; padding:8px 11px; border:1px solid var(--line); white-space:nowrap;}
+  td{padding:7px 11px; border:1px solid var(--line); vertical-align:top;}
+  tbody tr:nth-child(even){background:rgba(255,255,255,.02);}
+  td.k{white-space:nowrap; color:var(--ink-dim); font-weight:600;}
+  ul,ol{margin:8px 0 8px 22px;}
+  li{margin:5px 0;}
+  blockquote{border-left:3px solid var(--gold); background:rgba(201,163,95,.06); padding:12px 18px; margin:16px 0; color:var(--ink-dim); border-radius:0 6px 6px 0;}
+  .src{color:var(--ink-faint); font-size:12px;}
+  .toc{columns:2; column-gap:40px; font-size:14px; margin:10px 0;}
+  .toc a{color:var(--ink-dim); text-decoration:none; display:block; padding:3px 0;}
+  .toc a:hover{color:var(--gold-soft);}
+  .pill{display:inline-block; background:rgba(201,163,95,.12); color:var(--gold-soft); border:1px solid rgba(201,163,95,.4); border-radius:4px; padding:0 8px; font-size:12px; margin-right:6px; letter-spacing:.08em;}
+  footer{margin-top:64px; padding-top:20px; border-top:1px solid var(--line); color:var(--ink-faint); font-size:12.5px;}
+  .hr-gold{height:1px; background:linear-gradient(90deg,transparent,var(--gold),transparent); border:0; margin:36px 0;}
+  .big{font-size:16px;}
+  code{font-family:Consolas,Menlo,monospace; font-size:12.5px; background:rgba(255,255,255,.06); padding:1px 6px; border-radius:4px; color:var(--gold-soft);}
+  pre{font-family:Consolas,Menlo,monospace; font-size:12px; background:#0c0f13; border:1px solid var(--line); border-radius:8px; padding:14px 18px; overflow-x:auto; color:#c9d2dc; line-height:1.6; margin:12px 0;}
+  pre b{color:var(--gold-soft); font-weight:600;}
+  @media(max-width:720px){ .toc{columns:1;} .wrap{padding:0 18px;} h1{font-size:26px;} }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="wrap">
+    <div class="kicker">Technical Reconnaissance · 逆向技术侦察(静态)</div>
+    <h1>KMate 技术侦察报告
+      <span class="sub">Windows 桌面版 3.8.16 · 安装技术栈 / 数据目录 / km3.dat 数据格式 / 行为情报 / 迁移对照</span>
+    </h1>
+    <div class="meta">报告日期 <b>2026-09-05</b> · 侦察对象:本机安装(MSIX)与用户数据目录 · 方法:<b>文件级静态观察,未执行程序、未反编译、未复制任何代码</b></div>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <h2><span class="no">◆</span>报告摘要</h2>
+  <div class="card">
+    <ul>
+      <li><b>KMate Windows 桌面版 = Python 3.12 + PyInstaller 打包</b>,核心业务 mypyc 编译为原生 <code>.pyd</code>;UI 为 <b>wxPython 外壳 + WebView2 渲染 HTML 视图</b>。</li>
+      <li>数据极简:<b>一个 SQLite 主库 <code>km3.dat</code></b> + 两个 JSON 配置 + 缓存/日志骨架;应用视角路径 <code>%LOCALAPPDATA%\KMate\</code>(MSIX 重定向至 Packages 目录)。</li>
+      <li><b>km3.dat 与旧 KM2.dat / KindleMate2 同源</b>:表名与列名几乎一致,新增 <code>source / note_parent_key / ck_synced / pagenumber</code> 及书目、标签、闪卡状态结构。</li>
+      <li>行为情报:Windows“云同步”实为<b>把库绑定到云盘路径做文件级同步</b>;微信读书导入 = WebView2 内嵌登录页轮询;词典含自研 MDict(mdx)解析(minilzo)。</li>
+      <li>工程含义:KindleMate2 做“导入 KMate 数据”<b>可直接读 km3.dat 走 SQL 迁移</b>,主要差异点是 <code>key</code>(32 位 hex)与 <code>source</code> 语义。</li>
+    </ul>
+  </div>
+
+  <div class="grid">
+    <div class="stat"><div class="n">3.8.16</div><div class="l">桌面版本(2026-08-21)</div></div>
+    <div class="stat"><div class="n">Python 3.12</div><div class="l">运行时 + PyInstaller onedir</div></div>
+    <div class="stat"><div class="n">km3.dat</div><div class="l">SQLite 3 · 主库(7.4 MB 实测)</div></div>
+    <div class="stat"><div class="n">9 张表</div><div class="l">无触发器 · 索引齐备</div></div>
+  </div>
+
+  <hr class="hr-gold">
+
+  <h2><span class="no">◆</span>目录</h2>
+  <div class="toc">
+    <a href="#s1">一、侦察范围与方法</a>
+    <a href="#s2">二、安装技术栈(程序目录)</a>
+    <a href="#s3">三、数据目录结构</a>
+    <a href="#s4">四、主库 km3.dat 数据格式详解</a>
+    <a href="#s5">五、配置与行为情报</a>
+    <a href="#s6">六、与 KindleMate2(KM2 格式)迁移对照</a>
+    <a href="#s7">七、结论与工程建议</a>
+    <a href="#s8">附录:观察清单与局限</a>
+  </div>
+
+  <hr class="hr-gold">
+
+  <!-- 一 -->
+  <h2 id="s1"><span class="no">01</span>侦察范围与方法</h2>
+  <p class="lede">只读静态观察;所有结论来自文件名字、目录结构与数据库元数据,不构成对内部实现的完整断言。</p>
+  <table>
+    <thead><tr><th>对象</th><th>位置</th></tr></thead>
+    <tbody>
+      <tr><td class="k">安装目录</td><td><code>C:\Program Files\WindowsApps\KMateTeam.KMate-KindleClippingsVocabulary_3.8.16.0_neutral__nmhyc6rsazbye</code>(MSIX,含 AppxManifest.xml)</td></tr>
+      <tr><td class="k">数据目录</td><td><code>C:\Users\Rainy\AppData\Local\Packages\KMateTeam.KMate-KindleClippingsVocabulary_nmhyc6rsazbye\LocalCache\Local\KMate\</code>(应用视角 = <code>%LOCALAPPDATA%\KMate\</code>)</td></tr>
+      <tr><td class="k">包标识</td><td>PackageFamilyName <code>KMateTeam.KMate-KindleClippingsVocabulary_nmhyc6rsazbye</code>;商店 SKU 0010(full)/0011(trial);发布者 CN=7C98EFA7-…</td></tr>
+      <tr><td class="k">时间</td><td>2026-09-05(安装/数据写入 2026-09-04 23:59 – 09-05 00:08)</td></tr>
+    </tbody>
+  </table>
+
+  <hr class="hr-gold">
+
+  <!-- 二 -->
+  <h2 id="s2"><span class="no">02</span>安装技术栈(程序目录)</h2>
+  <p class="lede">一句话:<b>不是 .NET 程序,而是 Python 3.12 + PyInstaller 打包的桌面应用</b>,核心逻辑 mypyc 编译,UI 走 wxPython + WebView2(HTML)混合架构。</p>
+
+  <h3>2.1 分层技术栈</h3>
+  <table>
+    <thead><tr><th>层</th><th>技术</th><th>证据(安装目录)</th><th>解读</th></tr></thead>
+    <tbody>
+      <tr><td class="k">分发</td><td>MSIX(微软商店)</td><td>AppxManifest.xml:Windows.Desktop、runFullTrust、ProcessorArchitecture=neutral、7 语言资源</td><td>全信任 Win32 打包(非 UWP),单包分发</td></tr>
+      <tr><td class="k">运行时</td><td>Python 3.12</td><td>python312.dll、base_library.zip、_internal 目录布局</td><td>PyInstaller onedir 模式</td></tr>
+      <tr><td class="k">核心逻辑</td><td>mypyc 编译</td><td><code>81d243bd…__mypyc.cp312-win_amd64.pyd</code></td><td>业务代码编译为原生扩展:性能 + 反逆向</td></tr>
+      <tr><td class="k">UI 框架</td><td>wxPython 4.x</td><td>_internal/wx:wxmsw32u_core / webview / richtext / html / dataview + svg 扩展</td><td>原生窗口外壳与控件</td></tr>
+      <tr><td class="k">渲染层</td><td>WebView2(Edge)</td><td>WebView2Loader.dll、wxmsw32u_webview、modules/**/templates + static(HTML/CSS/JS)</td><td>阅读/详情/统计等视图用 HTML 渲染(Jinja2 风格模板)</td></tr>
+      <tr><td class="k">存储</td><td>SQLite</td><td>_sqlite3.pyd + sqlite3.dll</td><td>本地单文件库(km3.dat)</td></tr>
+      <tr><td class="k">设备连接</td><td>WinRT + libusb</td><td>winsdk/_winrt.pyd、libusb-1.0.dll</td><td>Kindle MTP/USB 识别与同步</td></tr>
+      <tr><td class="k">词典引擎</td><td>自研 mdx 插件</td><td>modules/dict_management/mdx_plugin/minilzo.dll</td><td>MDict 格式解压(minilzo)内嵌实现</td></tr>
+      <tr><td class="k">辅助库</td><td>lxml / numpy / PIL</td><td>lxml、numpy-2.4.4 + numpy.libs、PIL</td><td>解析 / 数据处理 / 封面图像</td></tr>
+      <tr><td class="k">网络</td><td>OpenSSL + requests 系</td><td>libssl-3 / libcrypto-3、certifi、charset_normalizer、dateutil</td><td>在线词典 / AI 查词 / Amazon 云端导入</td></tr>
+    </tbody>
+  </table>
+
+  <h3>2.2 业务模块划分(由打包资源反推)</h3>
+  <div class="card">
+    <p style="margin:0"><span class="pill">modules/note_view</span><span class="pill">modules/vocab_view</span><span class="pill">modules/reading_mode_note</span><span class="pill">modules/dict_management</span><span class="pill">modules/detail_view</span><span class="pill">note_markdown.css/js</span></p>
+    <p style="margin:8px 0 0; font-size:13px" class="src">标注视图(note_detail / note_reading_mode / note_empty_data / note_placeholder / note_new_book)、生词视图(vocab_detail 等)、阅读模式(reading_mode_note,含 global_stats 统计页)、词典管理(mdx_plugin)、详情静态资源。代码按“视图”垂直切片,与官网“数据库模式 / 阅读模式”双模式对应。</p>
+  </div>
+
+  <hr class="hr-gold">
+
+  <!-- 三 -->
+  <h2 id="s3"><span class="no">03</span>数据目录结构</h2>
+  <p class="lede">MSIX 将应用写盘重定向到 Packages 目录;数据本体极为精简。</p>
+  <pre>
+LocalCache\Local\KMate\                    <b>← 核心(应用视角 %LOCALAPPDATA%\KMate)</b>
+├─ km3.dat                 主库 SQLite3(命名延续旧 KM2.dat)
+├─ km_cfg.json             主配置 ≈5.8 KB
+├─ dict_cfg.json           词典配置 160 B
+├─ Backup\                 备份目录(空)
+├─ Cache\
+│  ├─ dictionaries\indices\     词典检索索引(如 mdx 全文)
+│  ├─ dictionaries\resources\   词典资源(图片/音频等)
+│  ├─ reading_mode\covers\      阅读模式书籍封面
+│  ├─ reading_mode\stats\       统计缓存
+│  ├─ print_cards\              打印卡片
+│  ├─ webview_pages\            WebView 页面
+│  └─ maintenance\.last_cleanup
+└─ logs\
+   ├─ kmate.log            主日志(级别 ERROR,常态为空)
+   └─ weread_import.log    微信读书导入日志
+
+LocalCache\Roaming\KMate\WebView2Data\EBWebView\   <b>← WebView2(Chromium)数据</b>
+  </pre>
+  <p class="src">实测 Cache 各子目录当前为空骨架(未安装词典、未用标签/封面)。数据规模:km3.dat 7.4 MB(clippings 5,988 / lines 5,991 / vocab 172 / lookups 175)。</p>
+
+  <hr class="hr-gold">
+
+  <!-- 四 -->
+  <h2 id="s4"><span class="no">04</span>主库 km3.dat 数据格式详解</h2>
+  <p class="lede"><code>user_version=0</code>;9 张表,无触发器,索引齐备。列语义为按列名与样本推断。</p>
+
+  <h3>4.1 表总览</h3>
+  <table>
+    <thead><tr><th>表</th><th>实测行数</th><th>作用</th><th>关键索引</th></tr></thead>
+    <tbody>
+      <tr><td class="k">clippings</td><td>5,988</td><td>标注/笔记主表</td><td>key、bookname、authorname、date、read、tag、sync、<b>ck_synced</b>、created_at_date、note_parent_key、book_author_date</td></tr>
+      <tr><td class="k">original_clipping_lines</td><td>5,991</td><td>My Clippings 原始行(每条 ≤5 行)</td><td>key</td></tr>
+      <tr><td class="k">vocab</td><td>172</td><td>生词主表(含闪卡学习状态)</td><td>word_key、word、timestamp、frequency、category、tag、<b>ck_synced</b>、created_at</td></tr>
+      <tr><td class="k">lookups</td><td>175</td><td>词典查询记录(例句/词频源)</td><td>word_key、title、timestamp、<b>ck_synced</b>、unique_norm</td></tr>
+      <tr><td class="k">books</td><td>0</td><td>书目独立表(封面/元数据)</td><td>title_author</td></tr>
+      <tr><td class="k">tags_clippings / tags_vocab</td><td>0</td><td>标签定义表(标注/生词分域)</td><td>—</td></tr>
+      <tr><td class="k">pending_deletions</td><td>0</td><td>云同步删除队列</td><td>record_type</td></tr>
+      <tr><td class="k">sqlite_sequence</td><td>2</td><td>自增序列</td><td>—</td></tr>
+    </tbody>
+  </table>
+
+  <h3>4.2 clippings 列语义(与旧 KM2 格式对照)</h3>
+  <table>
+    <thead><tr><th>列</th><th>类型/形态(实测)</th><th>语义推断</th><th>KM2 对照</th></tr></thead>
+    <tbody>
+      <tr><td class="k">key</td><td>32 位 hex 唯一键</td><td>疑似 MD5(内容/书/时间组合);主键</td><td>主键格式不同,需核对</td></tr>
+      <tr><td class="k">content</td><td>标注正文</td><td>高亮/笔记文本</td><td>同列</td></tr>
+      <tr><td class="k">bookname / authorname</td><td>文本</td><td>书名/作者(原始)</td><td>同列</td></tr>
+      <tr><td class="k">brieftype</td><td>0 / 1</td><td>0=标注 5,967 / 1=笔记 21</td><td>枚举需核对</td></tr>
+      <tr><td class="k">clippingdate</td><td><code>2016-06-16 13:47:27</code></td><td>标注时间(本地时间字符串)</td><td>同</td></tr>
+      <tr><td class="k">source</td><td>文本;样本全为 <code>Kindle</code></td><td>来源:Kindle / 微信读书 / Apple Books / KMate…</td><td><b>新增</b></td></tr>
+      <tr><td class="k">note_parent_key</td><td>空(设备导入)</td><td>笔记↔所属标注关联(指向另一条 key)</td><td><b>新增</b></td></tr>
+      <tr><td class="k">read / sync</td><td>0/1</td><td>状态位(旧版遗留,仍参与过滤/同步)</td><td>遗留列(现仍用)</td></tr>
+      <tr><td class="k">tag</td><td>NULL</td><td>旧文本标签列(新版标签走 tags_* 关联表)</td><td>遗留列</td></tr>
+      <tr><td class="k">newbookname</td><td>NULL</td><td>改名映射后的新书名</td><td>遗留列(现为“名称映射”功能)</td></tr>
+      <tr><td class="k">colorRGB</td><td>''</td><td>Kindle App 彩色标注色值</td><td>遗留列</td></tr>
+      <tr><td class="k">pagenumber</td><td>16 / 80…</td><td>页码(设备导入)</td><td><b>新增</b></td></tr>
+      <tr><td class="k">ck_synced</td><td>0/1</td><td>云同步标记(配 idx_*_ck_synced)</td><td><b>新增</b></td></tr>
+      <tr><td class="k">created_at / updated_at</td><td>时间</td><td>审计时间戳</td><td>同</td></tr>
+    </tbody>
+  </table>
+
+  <h3>4.3 其余表要点</h3>
+  <ul>
+    <li><b>original_clipping_lines</b>(id, key, line1…line5):My Clippings 逐行原文;行数 5,991 &gt; clippings 5,988,去重合并时原行被保留到保留条目(需在迁移时验证此规则)。</li>
+    <li><b>vocab</b>:word 显示词、stem 词干、translation(富文本)与 translation_plain(纯文本)、dict_source(词典来源)、frequency(词频);<b>last_reviewed / review_count / word_level = 闪卡学习状态字段</b>;colorRGB 同标注表。</li>
+    <li><b>lookups</b>:word_key 带<b>语言前缀</b>(样本 <code>zh:潜龙勿用</code>,英文为 <code>en:…</code>);usage 存原句、title/authors 记录所在书;idx_lookups_unique_norm 提供规范化去重。</li>
+    <li><b>books</b>:title/author/isbn/language/genre/publication_year + image_data(BLOB 封面)/image_url;是“书目编辑 + 名称映射 + Apple Books 书目”的落点(当前 0 行)。</li>
+      <li><b>tags_* / pending_deletions</b>:标签与同步删除队列结构已建,待使用。</li>
+    </ul>
+
+  <h3>4.4 完整结构清单(列 × 索引速查)</h3>
+  <p class="src">由原 <code>docs/KMate_数据格式情报.md</code> 并入(该文件已删除);<code>*</code> = 唯一索引/主键。</p>
+  <table>
+    <thead><tr><th>表</th><th>列</th><th>索引</th></tr></thead>
+    <tbody>
+      <tr><td class="k">clippings</td><td>key*, content, bookname, authorname, brieftype, clippingdate, read, tag, source, note_parent_key, sync, ck_synced, newbookname, colorRGB, pagenumber, created_at, updated_at</td><td>idx_key / bookname / authorname / date / read / tag / sync / ck_synced / created_at_date / note_parent_key / book_author_date</td></tr>
+      <tr><td class="k">original_clipping_lines</td><td>id*, key, line1, line2, line3, line4, line5, created_at, updated_at</td><td>idx_key</td></tr>
+      <tr><td class="k">vocab</td><td>id*, word_key, word, stem, category, translation, translation_plain, dict_source, timestamp, frequency, sync, ck_synced, colorRGB, last_reviewed, review_count, word_level, created_at, updated_at</td><td>idx_word_key / word / timestamp / frequency / category / tag / ck_synced / created_at</td></tr>
+      <tr><td class="k">lookups</td><td>id*, word_key, usage, title, authors, timestamp, ck_synced</td><td>idx_word_key / title / timestamp / ck_synced / <b>unique_norm</b>(规范化去重)</td></tr>
+      <tr><td class="k">books</td><td>id*, title, author, isbn, language, genre, publication_year, created_at, updated_at, image_data(BLOB), image_url</td><td>idx_title_author</td></tr>
+      <tr><td class="k">tags_clippings / tags_vocab</td><td>id*, name, color, description, created_at, updated_at</td><td>(主键)</td></tr>
+      <tr><td class="k">pending_deletions</td><td>record_name*, record_type, deleted_at</td><td>idx_record_type</td></tr>
+      <tr><td class="k">sqlite_sequence</td><td>name, seq</td><td>—</td></tr>
+    </tbody>
+  </table>
+  <p class="src">观察:三张内容主表均配 <code>idx_*_ck_synced</code>(同步批次查询);clippings/original_clipping_lines 共享 key 关联;lookups 的 unique_norm 承担“同一词条唯一化”。</p>
+
+  <hr class="hr-gold">
+
+  <!-- 五 -->
+  <h2 id="s5"><span class="no">05</span>配置与行为情报</h2>
+
+  <h3>5.1 km_cfg.json 解读</h3>
+  <table>
+    <thead><tr><th>配置段</th><th>关键内容与情报</th></tr></thead>
+    <tbody>
+      <tr><td class="k">database</td><td><code>database_path</code> = 应用视角 <code>%LOCALAPPDATA%\KMate\km3.dat</code>;database_version "3.0";migration_completed 标志</td></tr>
+      <tr><td class="k">database.云同步</td><td><code>use_cloud_sync + cloud_sync_path + cloud_sync_server_change_token + cloud_sync_last_bound_path/baseline_*</code> —— <b>Windows“云同步”= 把库绑定到云盘文件夹做文件级同步</b>(配合向移动端移交库),并非服务端账号同步</td></tr>
+      <tr><td class="k">kindle_device</td><td>授权根路径与书签(安全作用域)、authorization_schema_version=2、最近连接 Kindle 卷名</td></tr>
+      <tr><td class="k">ui_state</td><td>阅读模式 <code>reading_view_mode</code>(card/list/article)、侧栏 <code>cover</code>、<code>detail_markdown_enabled</code>、<code>detail_inline_tags_enabled</code>、树分组模式、窗口/分栏几何与列宽</td></tr>
+      <tr><td class="k">font / app</td><td>系统字体(微软雅黑)、字号表;app.version=3.8.16、theme、ignore_deleted_imports、restore_last_view</td></tr>
+      <tr><td class="k">export_settings</td><td>导出内容开关(content/bookname/clippingdate/…)、间隔 <code>interval_type=empty_line</code>、<code>kindle_app_color</code>(Kindle App 彩色标注)、show_related_notes</td></tr>
+      <tr><td class="k">anki_settings</td><td><b>Anki 卡片设计:正面 = word + usage + bookname + timestamp;背面 = definition</b>;<code>anki_definition_use_raw_html</code>、export_vocab_tags</td></tr>
+      <tr><td class="k">dict_*</td><td>词典管理对话框列宽与排序状态(dict_column_widths: enable/name/format/count)</td></tr>
+    </tbody>
+  </table>
+
+  <h3>5.2 dict_cfg.json</h3>
+  <p><code>dictionaries.dictionary_path</code>(默认空,词典存本机目录)、<code>dictionary_version</code>(形如 20260905)、<code>default_dictionary_id</code>、<code>dictionary_list[]</code>。</p>
+
+  <h3>5.3 日志揭示的微信读书导入机制</h3>
+  <blockquote>weread_import.log 显示:WebView2 打开 <code>weread.qq.com</code> → 轮询 <code>logged_in</code> / <code>total_books</code> → 呈现二维码(<code>auth_qr_ready</code>,带会话 uid)→ 登录后抓取。<b>无独立 API 凭据,依赖网页登录态</b>——这也是应用必须内置 Chromium 的原因之一。</blockquote>
+
+  <hr class="hr-gold">
+
+  <!-- 六 -->
+  <h2 id="s6"><span class="no">06</span>与 KindleMate2(KM2 格式)迁移对照</h2>
+  <p class="lede">两库同源、列名基本一致,迁移可走 SQL 级搬运;风险点集中标注如下。</p>
+  <table>
+    <thead><tr><th>km3 表</th><th>目标(KM2 侧)</th><th>注意点</th></tr></thead>
+    <tbody>
+      <tr><td class="k">clippings</td><td>clippings</td><td><code>key</code>(32 hex)与 KM2 主键格式不同:<b>建议保留原 key 到独立列,目标主键重建</b>;brieftype 0/1 枚举需与 KM2 定义核对;source 落新列或前缀;note_parent_key 关系需随迁并重建索引;忽略 read/sync/ck_synced 或置默认</td></tr>
+      <tr><td class="k">original_clipping_lines</td><td>original_clipping_lines</td><td>按 key 关联搬运;行数 &gt; clippings 的现象需在迁移逻辑中容忍(保留行映射)</td></tr>
+      <tr><td class="k">vocab</td><td>vocab</td><td><code>word_key</code> 语言前缀(zh:/en:)需兼容;translation_plain/dict_source 若 KM2 无对应列可忽略或并入 translation;学习状态列(last_reviewed/review_count/word_level)可直接保留以备将来</td></tr>
+      <tr><td class="k">lookups</td><td>lookups</td><td>word_key 前缀同上;usage/title 直接搬</td></tr>
+      <tr><td class="k">books</td><td>(KM2 无独立书目表)</td><td>可选:新建书目表,或并入“书名规范/改名”功能复用</td></tr>
+      <tr><td class="k">tags_* / pending_deletions</td><td>(无)</td><td>暂忽略;标签可在 KM2 引入标签后迁移</td></tr>
+    </tbody>
+  </table>
+
+  <div class="card">
+    <p style="margin:0"><b>工程量判断(2026-09-05 本机样本 dry-run 实测):</b>按目标 schema 在内存中逐行回放,<b>clippings 5,988 / lines 5,991 / lookups 175 / vocab 172 全部插入成功、零冲突</b>。要点:</p>
+    <ul style="margin-top:6px">
+      <li>源 <code>key</code> 全部为 32-hex 且库内唯一 → 可直接作为目标主键;<code>clippings</code> 各列数值/时间格式与目标完全兼容(非标准时间 0、colorRGB 空 → -1 转换 0 失败)。</li>
+      <li><code>vocab</code>:源 INTEGER id 不能直搬,改用<b> word_key 派生 TEXT id</b>(样本 word_key 全唯一,0 冲突)即可。</li>
+      <li><code>original_clipping_lines</code> 比 clippings 多 <b>3 条孤儿行</b>(key 已被 KMate 去重清理):迁移时需按 <code>key ∈ clippings</code> 过滤。</li>
+      <li>需丢弃的字段/表:source / note_parent_key / ck_synced / created_at·updated_at / translation_plain / dict_source / 闪卡三列 / books / tags_* / pending_deletions(目标暂无对应结构)。</li>
+      <li>总体:属<b>中低工作量</b>的标准 SQLite 只读 → 目标库回放;风险集中在目标应用层去重/类型枚举,而非读取。</li>
+    </ul>
+  </div>
+
+  <hr class="hr-gold">
+
+  <!-- 七 -->
+  <h2 id="s7"><span class="no">07</span>结论与工程建议</h2>
+  <ul>
+    <li><b>“读 km3.dat 直接迁”成立</b>:KMate 数据库未加密、无自定义页编码、标准 SQLite,KindleMate2 的 Microsoft.Data.Sqlite 可直接只读打开。</li>
+    <li>建议实现<b>“导入 KMate 数据库(km3.dat)”</b>入口,与既有 KM2.dat 导入并列,复用去重与事务框架;导入同时记录 source,为将来的“来源分组”铺路。</li>
+    <li>迁移对账口径:clippings 按 (bookname, content 归一, clippingdate) 与 KM2 既存数据去重;生词按 word_key 归一。</li>
+    <li>本报告的工程细节版(含全部列清单与索引)见仓库 <code>docs/KMate_数据格式情报.md</code>。</li>
+  </ul>
+
+  <hr class="hr-gold">
+
+  <!-- 附录 -->
+  <h2 id="s8"><span class="no">08</span>附录:观察清单与局限</h2>
+  <h3>8.1 观察清单</h3>
+  <ul>
+    <li>AppxManifest.xml(包标识/能力/语言);_internal 顶层文件与目录(wx / winsdk / assets / modules 等)。</li>
+    <li>modules 业务资源(note_view / vocab_view / reading_mode_note / dict_management / detail_view 的 templates + static)。</li>
+    <li>用户数据目录结构、km_cfg.json / dict_cfg.json 全文、日志文件名与 weread_import.log 流程。</li>
+    <li>km3.dat:PRAGMA user_version、sqlite_master(表/索引/触发器)、各表行数与列清单、代表性样例行(内容截断)。</li>
+  </ul>
+  <h3>8.2 局限与声明</h3>
+  <ul>
+    <li>全部为<b>静态文件观察</b>:未运行程序、未反编译 pyd、未复制或分发任何第三方代码。</li>
+    <li>列语义按列名/样本推断;brieftype 枚举、key 生成算法、note_parent_key 非空形态(sample 为空)需对照 KMate 行为进一步验证。</li>
+    <li>本机样本仅 Kindle 来源、无标签/书目/Apple Books 数据,source 其它取值与 books/tags 表的实际数据形态未观测到。</li>
+    <li>本报告仅用于 KindleMate2 工程对标与个人学习,不用于绕过授权或再分发 KMate 内容。</li>
+  </ul>
+
+  <footer>
+    KindleMate2 仓库内部技术报告 · 由 WorkBuddy 于 2026-09-05 生成 · 数据格式情报已于同日并入本报告(§4.4)<br>
+    配套文档:<code>docs/KMate_vs_KindleMate2_分析报告.html</code>(产品与战略分析)
+  </footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 概述
新增对 KMate(kmate.io,原 Kindle Mate 复活版,3.8.16)数据库 `km3.dat` 的导入支持,实现 1:1 忠实迁移。

管理菜单新增「导入KMate数据库」(中/英/繁 4 语言资源)。

## 提交内容(3 个)
1. **feat `9ba923b`**:`KmateSourceReader`(源库只读映射,处理 km3 与 KM2 schema 差异:vocab.id INTEGER → word_key 派生 TEXT 主键、数值列归一、忽略 books/tags 等表)+ `KmateDatabaseService`(目标仓储写入、孤儿行过滤、lookups 复合判重)+ 工厂/DI + UI 菜单 + 合成测试
2. **perf `6942c63`**:单条写入 → 每表单事务批量写入,真实库导入 **12m31s → ~1s**;顺带修复 `OriginalClippingLineRepository.Add(List)` 未绑定事务的潜伏 bug
3. **fix `540dd6e`**:去重口径由"全局 content"改为 **(bookname, authorname, content)**,不再误删不同书中完全相同的标注

## 验证
- 全量测试 **13/13 通过**(含跨书同内容保留回归用例)
- 真实 km3.dat(3.8.16,5,988 条标注)端到端:**5,988/5,988 全量导入、0 丢失**,二次导入幂等,约 1 秒
- 源库全程只读,不修改

## 说明
- 仅实测 Kindle 来源数据;微信读书/Apple Books 等 `source` 行未覆盖(导入时忽略 source 列)
- 数据来自对 kmate.io/商店 API/本机安装目录的**静态研究**,无代码复制