### PR TITLE
feat: 导入 KMate km3.dat 数据库

### DIFF
--- a/KindleMate2.Application/DependencyInjection.cs
+++ b/KindleMate2.Application/DependencyInjection.cs
@@ -42,6 +42,7 @@ public static class DependencyInjection {
         // ── Application-level Managers (Singleton — stateless coordinators) ──
         services.AddSingleton<IVocabDatabaseServiceFactory, VocabDatabaseServiceFactory>();
         services.AddSingleton<IKmDatabaseServiceFactory, KmDatabaseServiceFactory>();
+        services.AddSingleton<IKmateDatabaseServiceFactory, KmateDatabaseServiceFactory>();
         services.AddSingleton<IDeviceManager>(sp => {
             var versionFilePath = Path.Combine(AppConstants.SystemPathName, AppConstants.VersionFileName);
             return new DeviceManager(versionFilePath);
@@ -58,6 +59,7 @@ public static class DependencyInjection {
                 sp.GetRequiredService<ILookupService>(),
                 sp.GetRequiredService<IVocabDatabaseServiceFactory>(),
                 sp.GetRequiredService<IKmDatabaseServiceFactory>(),
+                sp.GetRequiredService<IKmateDatabaseServiceFactory>(),
                 importPath);
         });
         services.AddSingleton<IDataDisplayService, DataDisplayService>();

--- a/KindleMate2.Application/Services/IImportManager.cs
+++ b/KindleMate2.Application/Services/IImportManager.cs
@@ -5,4 +5,5 @@ public interface IImportManager {
     string ImportKindleClippings(string clippingsPath);
     string ImportKindleWords(string kindleWordsPath);
     string ImportKmDatabase(string filePath);
+    string ImportKmateDatabase(string filePath);
 }

--- a/KindleMate2.Application/Services/IKmateDatabaseServiceFactory.cs
+++ b/KindleMate2.Application/Services/IKmateDatabaseServiceFactory.cs
@@ -1,0 +1,11 @@
+using KindleMate2.Application.Services.KM2DB;
+
+namespace KindleMate2.Application.Services;
+
+/// <summary>
+/// Factory for creating <see cref="KmateDatabaseService"/> instances wired with
+/// the target KM2 repositories and a read-only path to the KMate km3.dat source.
+/// </summary>
+public interface IKmateDatabaseServiceFactory {
+    KmateDatabaseService Create(string km3DbPath);
+}

--- a/KindleMate2.Application/Services/ImportManager.cs
+++ b/KindleMate2.Application/Services/ImportManager.cs
@@ -16,11 +16,13 @@ public class ImportManager : IImportManager {
     private readonly ILookupService _lookupService;
     private readonly IVocabDatabaseServiceFactory _vocabDatabaseServiceFactory;
     private readonly IKmDatabaseServiceFactory _kmDatabaseServiceFactory;
+    private readonly IKmateDatabaseServiceFactory _kmateDatabaseServiceFactory;
     private readonly string _importPath;
 
     public ImportManager(IKm2DatabaseService km2DatabaseService, IClippingService clippingService, IVocabService vocabService,
         IOriginalClippingLineService originalClippingLineService, ILookupService lookupService,
         IVocabDatabaseServiceFactory vocabDatabaseServiceFactory, IKmDatabaseServiceFactory kmDatabaseServiceFactory,
+        IKmateDatabaseServiceFactory kmateDatabaseServiceFactory,
         string importPath) {
         _km2DatabaseService = km2DatabaseService;
         _clippingService = clippingService;
@@ -29,6 +31,7 @@ public class ImportManager : IImportManager {
         _lookupService = lookupService;
         _vocabDatabaseServiceFactory = vocabDatabaseServiceFactory;
         _kmDatabaseServiceFactory = kmDatabaseServiceFactory;
+        _kmateDatabaseServiceFactory = kmateDatabaseServiceFactory;
         _importPath = importPath;
     }
 
@@ -95,6 +98,32 @@ public class ImportManager : IImportManager {
         }
 
         if (!kmDatabaseService.ImportFromKmDatabase()) {
+            return string.Empty;
+        }
+
+        _km2DatabaseService.CleanDatabase(string.Empty, out _);
+        _km2DatabaseService.UpdateFrequency();
+
+        clippingsCount = _clippingService.GetCount() - clippingsCount;
+        vocabCount = _vocabService.GetCount() - vocabCount;
+        var message = Strings.Parsed_X + Strings.Space + (clippingsCount + vocabCount) + Strings.Space + Strings.X_Records + Strings.Symbol_Comma +
+                      Strings.Imported_X + Strings.Space + clippingsCount + Strings.Space + Strings.X_Clippings + Strings.Symbol_Comma +
+                      vocabCount + Strings.Space + Strings.X_Vocabs;
+        return message;
+    }
+
+    public string ImportKmateDatabase(string filePath) {
+        var kmateDatabaseService = _kmateDatabaseServiceFactory.Create(filePath);
+
+        var clippingsCount = _clippingService.GetCount();
+        var vocabCount = _vocabService.GetCount();
+
+        if (File.Exists(filePath)) {
+            var backupFilePath = Path.Combine(_importPath, "KMate_" + DateTimeHelper.GetCurrentTimestamp() + FileExtension.DAT);
+            File.Copy(filePath, backupFilePath, true);
+        }
+
+        if (!kmateDatabaseService.ImportFromKmateDatabase()) {
             return string.Empty;
         }
 

--- a/KindleMate2.Application/Services/KM2DB/KMDatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KMDatabaseService.cs
@@ -38,22 +38,24 @@ namespace KindleMate2.Application.Services.KM2DB {
                     // Pre-fetch target data for O(1) in-memory dedup checks
                     var targetClippings = _clippingRepository.GetAll();
                     var targetClippingKeys = targetClippings.Select(c => c.Key).ToHashSet();
-                    var targetClippingContents = targetClippings
-                        .Where(c => c.Content != null)
-                        .Select(c => c.Content!)
-                        .ToHashSet();
+                    // Dedup scope is per (book, author, content) — shared with the KMate km3.dat
+                    // import (KmateDatabaseService / KmateDedup) so both import paths behave
+                    // consistently: the same sentence in two different books are two distinct
+                    // highlights and both are kept; a genuine duplicate of the same book still
+                    // shares book+author+content and is skipped.
+                    var targetClippingBookContents = targetClippings.Select(KmateDedup.BookContentKey).ToHashSet();
 
                     foreach (Clipping kmClipping in kmClippings) {
                         if (string.IsNullOrEmpty(kmClipping.Content)) {
                             continue;
                         }
                         if (!targetClippingKeys.Contains(kmClipping.Key) &&
-                            !targetClippingContents.Contains(kmClipping.Content)) {
+                            !targetClippingBookContents.Contains(KmateDedup.BookContentKey(kmClipping))) {
                             if (_clippingRepository.Add(kmClipping)) {
                                 // Keep the dedup sets in sync so a duplicate key/content later
                                 // in the same source file cannot trip the PRIMARY KEY constraint.
                                 targetClippingKeys.Add(kmClipping.Key);
-                                targetClippingContents.Add(kmClipping.Content);
+                                targetClippingBookContents.Add(KmateDedup.BookContentKey(kmClipping));
                             }
                         }
                     }

--- a/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
@@ -51,10 +51,11 @@ namespace KindleMate2.Application.Services.KM2DB {
                     // transaction per table via the repositories' batched Add overloads.
                     var targetClippings = _clippingRepository.GetAll();
                     var targetClippingKeys = targetClippings.Select(c => c.Key).ToHashSet();
-                    var targetClippingContents = targetClippings
-                        .Where(c => c.Content != null)
-                        .Select(c => c.Content!)
-                        .ToHashSet();
+                    // Dedup scope is per (book, author, content), not global content: the same
+                    // sentence highlighted in two different books are two distinct highlights and
+                    // must both be kept. A true duplicate import (same book re-imported from a
+                    // device/cloud/source) still shares book+author+content and is skipped.
+                    var targetBookContents = targetClippings.Select(ComposeBookContentKey).ToHashSet();
 
                     var clippingCandidates = new List<Clipping>();
                     foreach (Clipping kmClipping in data.Clippings) {
@@ -62,12 +63,12 @@ namespace KindleMate2.Application.Services.KM2DB {
                             continue;
                         }
                         if (!targetClippingKeys.Contains(kmClipping.Key) &&
-                            !targetClippingContents.Contains(kmClipping.Content)) {
+                            !targetBookContents.Contains(ComposeBookContentKey(kmClipping))) {
                             clippingCandidates.Add(kmClipping);
                             // Keep the dedup sets in sync so duplicates later in the same source
                             // cannot be added twice (the batched INSERT runs in one transaction).
                             targetClippingKeys.Add(kmClipping.Key);
-                            targetClippingContents.Add(kmClipping.Content);
+                            targetBookContents.Add(ComposeBookContentKey(kmClipping));
                         }
                     }
                     if (clippingCandidates.Count > 0) {
@@ -141,6 +142,13 @@ namespace KindleMate2.Application.Services.KM2DB {
         private static string ComposePair(string wordKey, string? timestamp) {
             // \u0001 is used as a separator that cannot appear in a word_key.
             return wordKey + "\u0001" + (timestamp ?? string.Empty);
+        }
+
+        private static string ComposeBookContentKey(Clipping clipping) {
+            // (book, author, content) scope; an empty author degrades to (book, "", content).
+            return (clipping.BookName ?? string.Empty) + "\u0001" +
+                   (clipping.AuthorName ?? string.Empty) + "\u0001" +
+                   clipping.Content;
         }
     }
 }

--- a/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
@@ -9,8 +9,9 @@ namespace KindleMate2.Application.Services.KM2DB {
     /// </summary>
     /// <remarks>
     /// Source rows are mapped by <see cref="KmateSourceReader"/> (the km3 schema differs from the KM2
-    /// target schema, so the shared repositories cannot read it directly). Target writes go through the
-    /// regular KM2 repositories. Deduplication mirrors <see cref="KmDatabaseService"/> with three
+    /// target schema, so the shared repositories cannot read it directly). Target reads (dedup pre-fetch)
+    /// use the regular KM2 repositories; target writes go through <see cref="KmateAtomicWriter"/> in a
+    /// single transaction (all-or-nothing). Deduplication mirrors <see cref="KmDatabaseService"/> with three
     /// km3-specific corrections:
     /// <list type="bullet">
     /// <item><c>original_clipping_lines</c> are only imported when their key belongs to an accepted
@@ -26,18 +27,21 @@ namespace KindleMate2.Application.Services.KM2DB {
         private readonly IOriginalClippingLineRepository _originalClippingLineRepository;
         private readonly IVocabRepository _vocabRepository;
         private readonly string _sourcePath;
+        private readonly string _targetConnectionString;
 
         public KmateDatabaseService(
             IClippingRepository clippingRepository,
             ILookupRepository lookupRepository,
             IOriginalClippingLineRepository originalClippingLineRepository,
             IVocabRepository vocabRepository,
-            string sourcePath) {
+            string sourcePath,
+            string targetConnectionString) {
             _clippingRepository = clippingRepository;
             _lookupRepository = lookupRepository;
             _originalClippingLineRepository = originalClippingLineRepository;
             _vocabRepository = vocabRepository;
             _sourcePath = sourcePath;
+            _targetConnectionString = targetConnectionString;
         }
 
         public bool ImportFromKmateDatabase() {
@@ -46,9 +50,13 @@ namespace KindleMate2.Application.Services.KM2DB {
                     return false;
                 }
 
+                var clippingCandidates = new List<Clipping>();
+                var lineCandidates = new List<OriginalClippingLine>();
+                var lookupCandidates = new List<Lookup>();
+                var vocabCandidates = new List<Vocab>();
+
                 if (data.Clippings.Count > 0 || data.OriginalClippingLines.Count > 0) {
-                    // Pre-fetch target data for O(1) in-memory dedup checks, then write in one
-                    // transaction per table via the repositories' batched Add overloads.
+                    // Pre-fetch target data for O(1) in-memory dedup checks.
                     var targetClippings = _clippingRepository.GetAll();
                     var targetClippingKeys = targetClippings.Select(c => c.Key).ToHashSet();
                     // Dedup scope is per (book, author, content), not global content: the same
@@ -57,7 +65,6 @@ namespace KindleMate2.Application.Services.KM2DB {
                     // device/cloud/source) still shares book+author+content and is skipped.
                     var targetBookContents = targetClippings.Select(ComposeBookContentKey).ToHashSet();
 
-                    var clippingCandidates = new List<Clipping>();
                     foreach (Clipping kmClipping in data.Clippings) {
                         if (string.IsNullOrEmpty(kmClipping.Content)) {
                             continue;
@@ -66,16 +73,12 @@ namespace KindleMate2.Application.Services.KM2DB {
                             !targetBookContents.Contains(ComposeBookContentKey(kmClipping))) {
                             clippingCandidates.Add(kmClipping);
                             // Keep the dedup sets in sync so duplicates later in the same source
-                            // cannot be added twice (the batched INSERT runs in one transaction).
+                            // cannot end up in the candidate list twice.
                             targetClippingKeys.Add(kmClipping.Key);
                             targetBookContents.Add(ComposeBookContentKey(kmClipping));
                         }
                     }
-                    if (clippingCandidates.Count > 0) {
-                        _clippingRepository.Add(clippingCandidates);
-                    }
 
-                    var lineCandidates = new List<OriginalClippingLine>();
                     var targetOriginalKeys = _originalClippingLineRepository.GetAllKeys().ToHashSet();
                     foreach (OriginalClippingLine kmLine in data.OriginalClippingLines) {
                         // Skip orphan lines whose key was removed from clippings by KMate's cleanup.
@@ -87,9 +90,6 @@ namespace KindleMate2.Application.Services.KM2DB {
                             targetOriginalKeys.Add(kmLine.Key);
                         }
                     }
-                    if (lineCandidates.Count > 0) {
-                        _originalClippingLineRepository.Add(lineCandidates);
-                    }
                 }
 
                 if (data.Lookups.Count > 0) {
@@ -98,7 +98,6 @@ namespace KindleMate2.Application.Services.KM2DB {
                         .Select(l => ComposePair(l.WordKey!, l.Timestamp))
                         .ToHashSet();
 
-                    var lookupCandidates = new List<Lookup>();
                     foreach (Lookup kmLookup in data.Lookups) {
                         if (string.IsNullOrWhiteSpace(kmLookup.WordKey)) {
                             continue;
@@ -109,15 +108,11 @@ namespace KindleMate2.Application.Services.KM2DB {
                             targetLookupPairs.Add(pair);
                         }
                     }
-                    if (lookupCandidates.Count > 0) {
-                        _lookupRepository.Add(lookupCandidates);
-                    }
                 }
 
                 if (data.Vocabs.Count > 0) {
                     var targetVocabIds = _vocabRepository.GetAll().Select(v => v.Id).ToHashSet();
 
-                    var vocabCandidates = new List<Vocab>();
                     foreach (Vocab kmVocab in data.Vocabs) {
                         if (string.IsNullOrWhiteSpace(kmVocab.Id)) {
                             continue;
@@ -127,10 +122,16 @@ namespace KindleMate2.Application.Services.KM2DB {
                             targetVocabIds.Add(kmVocab.Id);
                         }
                     }
-                    if (vocabCandidates.Count > 0) {
-                        _vocabRepository.Add(vocabCandidates);
-                    }
                 }
+
+                // All-or-nothing: candidates are written in a single connection + single transaction,
+                // so a failure anywhere rolls the whole import back (no partial migration).
+                KmateAtomicWriter.WriteAll(
+                    _targetConnectionString,
+                    clippingCandidates,
+                    lineCandidates,
+                    lookupCandidates,
+                    vocabCandidates);
 
                 return true;
             } catch (Exception e) {

--- a/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
@@ -63,19 +63,19 @@ namespace KindleMate2.Application.Services.KM2DB {
                     // sentence highlighted in two different books are two distinct highlights and
                     // must both be kept. A true duplicate import (same book re-imported from a
                     // device/cloud/source) still shares book+author+content and is skipped.
-                    var targetBookContents = targetClippings.Select(ComposeBookContentKey).ToHashSet();
+                    var targetBookContents = targetClippings.Select(KmateDedup.BookContentKey).ToHashSet();
 
                     foreach (Clipping kmClipping in data.Clippings) {
                         if (string.IsNullOrEmpty(kmClipping.Content)) {
                             continue;
                         }
                         if (!targetClippingKeys.Contains(kmClipping.Key) &&
-                            !targetBookContents.Contains(ComposeBookContentKey(kmClipping))) {
+                            !targetBookContents.Contains(KmateDedup.BookContentKey(kmClipping))) {
                             clippingCandidates.Add(kmClipping);
                             // Keep the dedup sets in sync so duplicates later in the same source
                             // cannot end up in the candidate list twice.
                             targetClippingKeys.Add(kmClipping.Key);
-                            targetBookContents.Add(ComposeBookContentKey(kmClipping));
+                            targetBookContents.Add(KmateDedup.BookContentKey(kmClipping));
                         }
                     }
 
@@ -143,13 +143,6 @@ namespace KindleMate2.Application.Services.KM2DB {
         private static string ComposePair(string wordKey, string? timestamp) {
             // \u0001 is used as a separator that cannot appear in a word_key.
             return wordKey + "\u0001" + (timestamp ?? string.Empty);
-        }
-
-        private static string ComposeBookContentKey(Clipping clipping) {
-            // (book, author, content) scope; an empty author degrades to (book, "", content).
-            return (clipping.BookName ?? string.Empty) + "\u0001" +
-                   (clipping.AuthorName ?? string.Empty) + "\u0001" +
-                   clipping.Content;
         }
     }
 }

--- a/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
@@ -1,0 +1,133 @@
+using KindleMate2.Domain.Entities.KM2DB;
+using KindleMate2.Domain.Interfaces.KM2DB;
+using KindleMate2.Infrastructure.Helpers;
+using KindleMate2.Infrastructure.Repositories.KM2DB;
+
+namespace KindleMate2.Application.Services.KM2DB {
+    /// <summary>
+    /// Imports data from a KMate (kmate.io) <c>km3.dat</c> database into the current KM2 database.
+    /// </summary>
+    /// <remarks>
+    /// Source rows are mapped by <see cref="KmateSourceReader"/> (the km3 schema differs from the KM2
+    /// target schema, so the shared repositories cannot read it directly). Target writes go through the
+    /// regular KM2 repositories. Deduplication mirrors <see cref="KmDatabaseService"/> with three
+    /// km3-specific corrections:
+    /// <list type="bullet">
+    /// <item><c>original_clipping_lines</c> are only imported when their key belongs to an accepted
+    /// <c>clippings</c> row — KMate leaves orphan lines behind after its own duplicate cleanup;</item>
+    /// <item><c>vocab</c> uses the word_key-derived TEXT id produced by the reader (source id is INTEGER);</item>
+    /// <item><c>lookups</c> are deduplicated on (word_key, timestamp) to respect the target UNIQUE constraint.</item>
+    /// </list>
+    /// The source file is only ever opened read-only.
+    /// </remarks>
+    public class KmateDatabaseService {
+        private readonly IClippingRepository _clippingRepository;
+        private readonly ILookupRepository _lookupRepository;
+        private readonly IOriginalClippingLineRepository _originalClippingLineRepository;
+        private readonly IVocabRepository _vocabRepository;
+        private readonly string _sourcePath;
+
+        public KmateDatabaseService(
+            IClippingRepository clippingRepository,
+            ILookupRepository lookupRepository,
+            IOriginalClippingLineRepository originalClippingLineRepository,
+            IVocabRepository vocabRepository,
+            string sourcePath) {
+            _clippingRepository = clippingRepository;
+            _lookupRepository = lookupRepository;
+            _originalClippingLineRepository = originalClippingLineRepository;
+            _vocabRepository = vocabRepository;
+            _sourcePath = sourcePath;
+        }
+
+        public bool ImportFromKmateDatabase() {
+            try {
+                if (!KmateSourceReader.TryRead(_sourcePath, out var data, out _)) {
+                    return false;
+                }
+
+                if (data.Clippings.Count > 0 || data.OriginalClippingLines.Count > 0) {
+                    // Pre-fetch target data for O(1) in-memory dedup checks.
+                    var targetClippings = _clippingRepository.GetAll();
+                    var targetClippingKeys = targetClippings.Select(c => c.Key).ToHashSet();
+                    var targetClippingContents = targetClippings
+                        .Where(c => c.Content != null)
+                        .Select(c => c.Content!)
+                        .ToHashSet();
+
+                    foreach (Clipping kmClipping in data.Clippings) {
+                        if (string.IsNullOrEmpty(kmClipping.Content)) {
+                            continue;
+                        }
+                        if (!targetClippingKeys.Contains(kmClipping.Key) &&
+                            !targetClippingContents.Contains(kmClipping.Content)) {
+                            if (_clippingRepository.Add(kmClipping)) {
+                                // Keep the dedup sets in sync so a duplicate key/content later
+                                // in the same source file cannot trip the PRIMARY KEY constraint.
+                                targetClippingKeys.Add(kmClipping.Key);
+                                targetClippingContents.Add(kmClipping.Content);
+                            }
+                        }
+                    }
+
+                    var targetOriginalKeys = _originalClippingLineRepository.GetAllKeys().ToHashSet();
+                    foreach (OriginalClippingLine kmLine in data.OriginalClippingLines) {
+                        // Skip orphan lines whose key was removed from clippings by KMate's cleanup.
+                        if (!targetClippingKeys.Contains(kmLine.Key)) {
+                            continue;
+                        }
+                        if (!targetOriginalKeys.Contains(kmLine.Key)) {
+                            if (_originalClippingLineRepository.Add(kmLine)) {
+                                targetOriginalKeys.Add(kmLine.Key);
+                            }
+                        }
+                    }
+                }
+
+                if (data.Lookups.Count > 0) {
+                    var targetLookupPairs = _lookupRepository.GetAll()
+                        .Where(l => l.WordKey != null)
+                        .Select(l => ComposePair(l.WordKey!, l.Timestamp))
+                        .ToHashSet();
+
+                    foreach (Lookup kmLookup in data.Lookups) {
+                        if (string.IsNullOrWhiteSpace(kmLookup.WordKey)) {
+                            continue;
+                        }
+                        var pair = ComposePair(kmLookup.WordKey, kmLookup.Timestamp);
+                        if (!targetLookupPairs.Contains(pair)) {
+                            if (_lookupRepository.Add(kmLookup)) {
+                                targetLookupPairs.Add(pair);
+                            }
+                        }
+                    }
+                }
+
+                if (data.Vocabs.Count > 0) {
+                    var targetVocabIds = _vocabRepository.GetAll().Select(v => v.Id).ToHashSet();
+
+                    foreach (Vocab kmVocab in data.Vocabs) {
+                        if (string.IsNullOrWhiteSpace(kmVocab.Id)) {
+                            continue;
+                        }
+                        if (!targetVocabIds.Contains(kmVocab.Id)) {
+                            if (_vocabRepository.Add(kmVocab)) {
+                                targetVocabIds.Add(kmVocab.Id);
+                            }
+                        }
+                    }
+                }
+
+                return true;
+            } catch (Exception e) {
+                Console.WriteLine(StringHelper.GetExceptionMessage(nameof(ImportFromKmateDatabase), e));
+                return false;
+            }
+        }
+
+        private static string ComposePair(string wordKey, string? timestamp) {
+            // \u0001 is used as a separator that cannot appear in a word_key.
+            return wordKey + "\u0001" + (timestamp ?? string.Empty);
+        }
+    }
+}

--- a/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KmateDatabaseService.cs
@@ -47,7 +47,8 @@ namespace KindleMate2.Application.Services.KM2DB {
                 }
 
                 if (data.Clippings.Count > 0 || data.OriginalClippingLines.Count > 0) {
-                    // Pre-fetch target data for O(1) in-memory dedup checks.
+                    // Pre-fetch target data for O(1) in-memory dedup checks, then write in one
+                    // transaction per table via the repositories' batched Add overloads.
                     var targetClippings = _clippingRepository.GetAll();
                     var targetClippingKeys = targetClippings.Select(c => c.Key).ToHashSet();
                     var targetClippingContents = targetClippings
@@ -55,21 +56,25 @@ namespace KindleMate2.Application.Services.KM2DB {
                         .Select(c => c.Content!)
                         .ToHashSet();
 
+                    var clippingCandidates = new List<Clipping>();
                     foreach (Clipping kmClipping in data.Clippings) {
                         if (string.IsNullOrEmpty(kmClipping.Content)) {
                             continue;
                         }
                         if (!targetClippingKeys.Contains(kmClipping.Key) &&
                             !targetClippingContents.Contains(kmClipping.Content)) {
-                            if (_clippingRepository.Add(kmClipping)) {
-                                // Keep the dedup sets in sync so a duplicate key/content later
-                                // in the same source file cannot trip the PRIMARY KEY constraint.
-                                targetClippingKeys.Add(kmClipping.Key);
-                                targetClippingContents.Add(kmClipping.Content);
-                            }
+                            clippingCandidates.Add(kmClipping);
+                            // Keep the dedup sets in sync so duplicates later in the same source
+                            // cannot be added twice (the batched INSERT runs in one transaction).
+                            targetClippingKeys.Add(kmClipping.Key);
+                            targetClippingContents.Add(kmClipping.Content);
                         }
                     }
+                    if (clippingCandidates.Count > 0) {
+                        _clippingRepository.Add(clippingCandidates);
+                    }
 
+                    var lineCandidates = new List<OriginalClippingLine>();
                     var targetOriginalKeys = _originalClippingLineRepository.GetAllKeys().ToHashSet();
                     foreach (OriginalClippingLine kmLine in data.OriginalClippingLines) {
                         // Skip orphan lines whose key was removed from clippings by KMate's cleanup.
@@ -77,10 +82,12 @@ namespace KindleMate2.Application.Services.KM2DB {
                             continue;
                         }
                         if (!targetOriginalKeys.Contains(kmLine.Key)) {
-                            if (_originalClippingLineRepository.Add(kmLine)) {
-                                targetOriginalKeys.Add(kmLine.Key);
-                            }
+                            lineCandidates.Add(kmLine);
+                            targetOriginalKeys.Add(kmLine.Key);
                         }
+                    }
+                    if (lineCandidates.Count > 0) {
+                        _originalClippingLineRepository.Add(lineCandidates);
                     }
                 }
 
@@ -90,31 +97,37 @@ namespace KindleMate2.Application.Services.KM2DB {
                         .Select(l => ComposePair(l.WordKey!, l.Timestamp))
                         .ToHashSet();
 
+                    var lookupCandidates = new List<Lookup>();
                     foreach (Lookup kmLookup in data.Lookups) {
                         if (string.IsNullOrWhiteSpace(kmLookup.WordKey)) {
                             continue;
                         }
                         var pair = ComposePair(kmLookup.WordKey, kmLookup.Timestamp);
                         if (!targetLookupPairs.Contains(pair)) {
-                            if (_lookupRepository.Add(kmLookup)) {
-                                targetLookupPairs.Add(pair);
-                            }
+                            lookupCandidates.Add(kmLookup);
+                            targetLookupPairs.Add(pair);
                         }
+                    }
+                    if (lookupCandidates.Count > 0) {
+                        _lookupRepository.Add(lookupCandidates);
                     }
                 }
 
                 if (data.Vocabs.Count > 0) {
                     var targetVocabIds = _vocabRepository.GetAll().Select(v => v.Id).ToHashSet();
 
+                    var vocabCandidates = new List<Vocab>();
                     foreach (Vocab kmVocab in data.Vocabs) {
                         if (string.IsNullOrWhiteSpace(kmVocab.Id)) {
                             continue;
                         }
                         if (!targetVocabIds.Contains(kmVocab.Id)) {
-                            if (_vocabRepository.Add(kmVocab)) {
-                                targetVocabIds.Add(kmVocab.Id);
-                            }
+                            vocabCandidates.Add(kmVocab);
+                            targetVocabIds.Add(kmVocab.Id);
                         }
+                    }
+                    if (vocabCandidates.Count > 0) {
+                        _vocabRepository.Add(vocabCandidates);
                     }
                 }
 

--- a/KindleMate2.Application/Services/KM2DB/KmateDedup.cs
+++ b/KindleMate2.Application/Services/KM2DB/KmateDedup.cs
@@ -1,0 +1,22 @@
+using KindleMate2.Domain.Entities.KM2DB;
+
+namespace KindleMate2.Application.Services.KM2DB;
+
+/// <summary>
+/// Shared deduplication keys for KM/KMate database imports (both the legacy KM2.dat import
+/// <see cref="KmDatabaseService"/> and the KMate km3.dat import <see cref="KmateDatabaseService"/>
+/// use the SAME scope so that the two import paths behave consistently).
+/// </summary>
+internal static class KmateDedup {
+    /// <summary>
+    /// Clipping dedup scope is per (book, author, content), not global content: the same sentence
+    /// highlighted in two different books are two distinct highlights and must both be kept. A true
+    /// duplicate import (same book re-imported from a device/cloud/source) still shares
+    /// book+author+content and is skipped. Empty author degrades to (book, "", content).
+    /// </summary>
+    public static string BookContentKey(Clipping clipping) {
+        return (clipping.BookName ?? string.Empty) + "\u0001" +
+               (clipping.AuthorName ?? string.Empty) + "\u0001" +
+               clipping.Content;
+    }
+}

--- a/KindleMate2.Application/Services/KmateDatabaseServiceFactory.cs
+++ b/KindleMate2.Application/Services/KmateDatabaseServiceFactory.cs
@@ -1,5 +1,6 @@
 using KindleMate2.Application.Services.KM2DB;
 using KindleMate2.Domain.Interfaces.KM2DB;
+using KindleMate2.Shared.Constants;
 
 namespace KindleMate2.Application.Services;
 
@@ -27,6 +28,7 @@ public class KmateDatabaseServiceFactory : IKmateDatabaseServiceFactory {
             _lookupRepository,
             _originalClippingLineRepository,
             _vocabRepository,
-            km3DbPath);
+            km3DbPath,
+            AppConstants.ConnectionString);
     }
 }

--- a/KindleMate2.Application/Services/KmateDatabaseServiceFactory.cs
+++ b/KindleMate2.Application/Services/KmateDatabaseServiceFactory.cs
@@ -1,0 +1,32 @@
+using KindleMate2.Application.Services.KM2DB;
+using KindleMate2.Domain.Interfaces.KM2DB;
+
+namespace KindleMate2.Application.Services;
+
+/// <inheritdoc cref="IKmateDatabaseServiceFactory"/>
+public class KmateDatabaseServiceFactory : IKmateDatabaseServiceFactory {
+    private readonly IClippingRepository _clippingRepository;
+    private readonly ILookupRepository _lookupRepository;
+    private readonly IOriginalClippingLineRepository _originalClippingLineRepository;
+    private readonly IVocabRepository _vocabRepository;
+
+    public KmateDatabaseServiceFactory(
+        IClippingRepository clippingRepository,
+        ILookupRepository lookupRepository,
+        IOriginalClippingLineRepository originalClippingLineRepository,
+        IVocabRepository vocabRepository) {
+        _clippingRepository = clippingRepository;
+        _lookupRepository = lookupRepository;
+        _originalClippingLineRepository = originalClippingLineRepository;
+        _vocabRepository = vocabRepository;
+    }
+
+    public KmateDatabaseService Create(string km3DbPath) {
+        return new KmateDatabaseService(
+            _clippingRepository,
+            _lookupRepository,
+            _originalClippingLineRepository,
+            _vocabRepository,
+            km3DbPath);
+    }
+}

--- a/KindleMate2.Infrastructure/Repositories/KM2DB/KmateAtomicWriter.cs
+++ b/KindleMate2.Infrastructure/Repositories/KM2DB/KmateAtomicWriter.cs
@@ -1,0 +1,129 @@
+using KindleMate2.Domain.Entities.KM2DB;
+using Microsoft.Data.Sqlite;
+
+namespace KindleMate2.Infrastructure.Repositories.KM2DB;
+
+/// <summary>
+/// All-or-nothing batched writer for KMate (km3.dat) imports.
+/// Inserts the four candidate sets (clippings / original_clipping_lines / lookups / vocab) inside a
+/// single connection and a single transaction: if any insert fails, everything is rolled back, so an
+/// import can never leave a partially migrated database behind.
+/// </summary>
+/// <remarks>
+/// Column lists and parameter mapping intentionally mirror the single/Add and Add(List) overloads of the
+/// KM2 repositories (ClippingRepository / OriginalClippingLineRepository / LookupRepository /
+/// VocabRepository). Keep them in sync if the KM2 schema evolves.
+/// </remarks>
+public static class KmateAtomicWriter {
+    public static void WriteAll(
+        string connectionString,
+        IReadOnlyList<Clipping> clippings,
+        IReadOnlyList<OriginalClippingLine> originalClippingLines,
+        IReadOnlyList<Lookup> lookups,
+        IReadOnlyList<Vocab> vocabs) {
+        if (clippings.Count == 0 && originalClippingLines.Count == 0 && lookups.Count == 0 && vocabs.Count == 0) {
+            return;
+        }
+
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+        using var transaction = connection.BeginTransaction();
+        try {
+            InsertClippings(connection, transaction, clippings);
+            InsertOriginalClippingLines(connection, transaction, originalClippingLines);
+            InsertLookups(connection, transaction, lookups);
+            InsertVocabs(connection, transaction, vocabs);
+            transaction.Commit();
+        } catch {
+            transaction.Rollback();
+            throw;
+        }
+    }
+
+    private static void InsertClippings(SqliteConnection connection, SqliteTransaction transaction, IReadOnlyList<Clipping> clippings) {
+        if (clippings.Count == 0) {
+            return;
+        }
+        using var cmd = new SqliteCommand(
+            "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingtypelocation, clippingdate, read, clipping_importdate, tag, sync, newbookname, colorRGB, pagenumber) VALUES (@key, @content, @bookname, @authorname, @brieftype, @clippingtypelocation, @clippingdate, @read, @clipping_importdate, @tag, @sync, @newbookname, @colorRGB, @pagenumber)",
+            connection, transaction);
+        foreach (Clipping clipping in clippings) {
+            cmd.Parameters.Clear();
+            cmd.Parameters.AddWithValue("@key", clipping.Key ?? throw new InvalidOperationException());
+            cmd.Parameters.AddWithValue("@content", clipping.Content);
+            cmd.Parameters.AddWithValue("@bookname", clipping.BookName ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@authorname", clipping.AuthorName ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@brieftype", clipping.BriefType ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@clippingtypelocation", clipping.ClippingTypeLocation ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@clippingdate", clipping.ClippingDate ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@read", clipping.Read ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@clipping_importdate", clipping.ClippingImportDate ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@tag", clipping.Tag ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@sync", clipping.Sync ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@newbookname", clipping.NewBookName ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@colorRGB", clipping.ColorRgb ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@pagenumber", clipping.PageNumber ?? (object)DBNull.Value);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    private static void InsertOriginalClippingLines(SqliteConnection connection, SqliteTransaction transaction, IReadOnlyList<OriginalClippingLine> lines) {
+        if (lines.Count == 0) {
+            return;
+        }
+        using var cmd = new SqliteCommand(
+            "INSERT INTO original_clipping_lines (key, line1, line2, line3, line4, line5) VALUES (@key, @line1, @line2, @line3, @line4, @line5)",
+            connection, transaction);
+        foreach (OriginalClippingLine line in lines) {
+            cmd.Parameters.Clear();
+            cmd.Parameters.AddWithValue("@key", line.Key ?? throw new InvalidOperationException());
+            cmd.Parameters.AddWithValue("@line1", line.Line1 ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@line2", line.Line2 ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@line3", line.Line3 ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@line4", line.Line4 ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@line5", line.Line5 ?? (object)DBNull.Value);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    private static void InsertLookups(SqliteConnection connection, SqliteTransaction transaction, IReadOnlyList<Lookup> lookups) {
+        if (lookups.Count == 0) {
+            return;
+        }
+        using var cmd = new SqliteCommand(
+            "INSERT INTO lookups (word_key, usage, title, authors, timestamp) VALUES (@word_key, @usage, @title, @authors, @timestamp)",
+            connection, transaction);
+        foreach (Lookup lookup in lookups) {
+            cmd.Parameters.Clear();
+            cmd.Parameters.AddWithValue("@word_key", lookup.WordKey ?? throw new InvalidOperationException());
+            cmd.Parameters.AddWithValue("@usage", lookup.Usage ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@title", lookup.Title ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@authors", lookup.Authors ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@timestamp", lookup.Timestamp ?? (object)DBNull.Value);
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    private static void InsertVocabs(SqliteConnection connection, SqliteTransaction transaction, IReadOnlyList<Vocab> vocabs) {
+        if (vocabs.Count == 0) {
+            return;
+        }
+        using var cmd = new SqliteCommand(
+            "INSERT INTO vocab (id, word_key, word, stem, category, translation, timestamp, frequency, sync, colorRGB) VALUES (@id, @word_key, @word, @stem, @category, @translation, @timestamp, @frequency, @sync, @colorRGB)",
+            connection, transaction);
+        foreach (Vocab vocab in vocabs) {
+            cmd.Parameters.Clear();
+            cmd.Parameters.AddWithValue("@id", vocab.Id ?? throw new InvalidOperationException());
+            cmd.Parameters.AddWithValue("@word_key", vocab.WordKey ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@word", vocab.Word ?? throw new InvalidOperationException());
+            cmd.Parameters.AddWithValue("@stem", vocab.Stem ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@category", vocab.Category ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@translation", vocab.Translation ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@timestamp", vocab.Timestamp ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@frequency", vocab.Frequency ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@sync", vocab.Sync ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@colorRGB", vocab.ColorRgb ?? (object)DBNull.Value);
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/KindleMate2.Infrastructure/Repositories/KM2DB/KmateSourceReader.cs
+++ b/KindleMate2.Infrastructure/Repositories/KM2DB/KmateSourceReader.cs
@@ -1,0 +1,209 @@
+using KindleMate2.Domain.Entities.KM2DB;
+using Microsoft.Data.Sqlite;
+
+namespace KindleMate2.Infrastructure.Repositories.KM2DB;
+
+/// <summary>
+/// Read-only mapper for KMate (kmate.io) <c>km3.dat</c> (SQLite). It maps the four tables that share
+/// their lineage with the legacy KM2 format (<c>clippings</c>, <c>original_clipping_lines</c>,
+/// <c>lookups</c>, <c>vocab</c>) onto the KM2 domain entities used by the target repositories.
+/// </summary>
+/// <remarks>
+/// The KMate source schema is NOT identical to the KM2 target schema, so the shared repositories
+/// cannot be pointed at it. Handled differences:
+/// <list type="bullet">
+/// <item>extra source columns (source / note_parent_key / ck_synced / created_at / updated_at / …) are ignored;</item>
+/// <item><c>vocab.id</c> is an INTEGER identity in km3 — a TEXT primary key is derived from <c>word_key</c>
+/// (word_key is unique in practice; rows without a usable key are skipped);</item>
+/// <item>numeric-ish TEXT columns (<c>colorRGB</c>, <c>category</c>, <c>frequency</c>, <c>pagenumber</c>) are
+/// parsed defensively (empty / non-numeric fall back to -1 / 0);</item>
+/// <item>km3 has no <c>settings</c> table and extra tables (<c>books</c>, <c>tags_*</c>, <c>pending_deletions</c>)
+/// are out of scope — they are ignored.</item>
+/// </list>
+/// The source file is opened with <c>Mode=ReadOnly</c> and never written to.
+/// </remarks>
+public static class KmateSourceReader {
+    public sealed record KmateData(
+        List<Clipping> Clippings,
+        List<OriginalClippingLine> OriginalClippingLines,
+        List<Lookup> Lookups,
+        List<Vocab> Vocabs);
+
+    /// <summary>
+    /// Reads a KMate km3.dat into KM2 entity candidates.
+    /// </summary>
+    /// <returns>True when the file exists and at least one of <c>clippings</c>/<c>vocab</c> is present.</returns>
+    public static bool TryRead(string sourcePath, out KmateData data, out string error) {
+        data = null!;
+        error = string.Empty;
+
+        if (!File.Exists(sourcePath)) {
+            error = "KMate database file not found: " + sourcePath;
+            return false;
+        }
+
+        try {
+            using var connection = new SqliteConnection($"Data Source={sourcePath};Mode=ReadOnly;");
+            connection.Open();
+
+            var tables = GetTableNames(connection);
+            if (!tables.Contains("clippings") && !tables.Contains("vocab")) {
+                error = "Not a KMate (km3.dat) database — no clippings/vocab table found.";
+                return false;
+            }
+
+            var clippings = tables.Contains("clippings")
+                ? ReadClippings(connection)
+                : new List<Clipping>();
+            var lines = tables.Contains("original_clipping_lines")
+                ? ReadOriginalClippingLines(connection)
+                : new List<OriginalClippingLine>();
+            var lookups = tables.Contains("lookups")
+                ? ReadLookups(connection)
+                : new List<Lookup>();
+            var vocabs = tables.Contains("vocab")
+                ? ReadVocabs(connection)
+                : new List<Vocab>();
+
+            data = new KmateData(clippings, lines, lookups, vocabs);
+            return true;
+        } catch (Exception e) {
+            error = e.Message;
+            return false;
+        }
+    }
+
+    private static HashSet<string> GetTableNames(SqliteConnection connection) {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT name FROM sqlite_master WHERE type = 'table'";
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            names.Add(reader.GetString(0));
+        }
+        return names;
+    }
+
+    private static List<Clipping> ReadClippings(SqliteConnection connection) {
+        var results = new List<Clipping>();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT key, content, bookname, authorname, brieftype, clippingdate, colorRGB, pagenumber FROM clippings";
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            var key = GetString(reader, 0);
+            if (string.IsNullOrEmpty(key)) {
+                continue;
+            }
+            results.Add(new Clipping {
+                Key = key,
+                Content = GetString(reader, 1) ?? string.Empty,
+                BookName = GetString(reader, 2),
+                AuthorName = GetString(reader, 3),
+                BriefType = reader.IsDBNull(4) ? null : reader.GetInt64(4),
+                ClippingDate = GetString(reader, 5),
+                Read = 0,
+                Sync = 0,
+                ColorRgb = ParseLong(reader, 6, -1),
+                PageNumber = ParseInt(reader, 7, 0)
+            });
+        }
+        return results;
+    }
+
+    private static List<OriginalClippingLine> ReadOriginalClippingLines(SqliteConnection connection) {
+        var results = new List<OriginalClippingLine>();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT key, line1, line2, line3, line4, line5 FROM original_clipping_lines";
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            var key = GetString(reader, 0);
+            if (string.IsNullOrEmpty(key)) {
+                continue;
+            }
+            results.Add(new OriginalClippingLine {
+                Key = key,
+                Line1 = GetString(reader, 1),
+                Line2 = GetString(reader, 2),
+                Line3 = GetString(reader, 3),
+                Line4 = GetString(reader, 4),
+                Line5 = GetString(reader, 5)
+            });
+        }
+        return results;
+    }
+
+    private static List<Lookup> ReadLookups(SqliteConnection connection) {
+        var results = new List<Lookup>();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT word_key, usage, title, authors, timestamp FROM lookups";
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            var wordKey = GetString(reader, 0);
+            if (string.IsNullOrWhiteSpace(wordKey)) {
+                continue;
+            }
+            results.Add(new Lookup {
+                WordKey = wordKey,
+                Usage = GetString(reader, 1),
+                Title = GetString(reader, 2),
+                Authors = GetString(reader, 3),
+                Timestamp = GetString(reader, 4)
+            });
+        }
+        return results;
+    }
+
+    private static List<Vocab> ReadVocabs(SqliteConnection connection) {
+        var results = new List<Vocab>();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT word_key, word, stem, category, translation, timestamp, frequency, colorRGB FROM vocab";
+        using var reader = command.ExecuteReader();
+        while (reader.Read()) {
+            var wordKey = GetString(reader, 0);
+            var word = GetString(reader, 1);
+            if (string.IsNullOrWhiteSpace(word)) {
+                continue;
+            }
+            // km3 vocab.id is an INTEGER identity; derive a stable TEXT primary key from word_key.
+            var id = !string.IsNullOrWhiteSpace(wordKey)
+                ? wordKey
+                : word;
+            results.Add(new Vocab {
+                Id = id,
+                WordKey = wordKey,
+                Word = word,
+                Stem = GetString(reader, 2),
+                Category = ParseLong(reader, 3, 0),
+                Translation = GetString(reader, 4),
+                Timestamp = GetString(reader, 5),
+                Frequency = ParseInt(reader, 6, 0),
+                Sync = 0,
+                ColorRgb = ParseLong(reader, 7, -1)
+            });
+        }
+        return results;
+    }
+
+    private static string? GetString(SqliteDataReader reader, int ordinal) {
+        return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+    }
+
+    private static long ParseLong(SqliteDataReader reader, int ordinal, long fallback) {
+        if (reader.IsDBNull(ordinal)) {
+            return fallback;
+        }
+        var raw = Convert.ToString(reader.GetValue(ordinal), System.Globalization.CultureInfo.InvariantCulture);
+        return long.TryParse(raw, out var value) ? value : fallback;
+    }
+
+    private static int ParseInt(SqliteDataReader reader, int ordinal, int fallback) {
+        if (reader.IsDBNull(ordinal)) {
+            return fallback;
+        }
+        var raw = Convert.ToString(reader.GetValue(ordinal), System.Globalization.CultureInfo.InvariantCulture);
+        return int.TryParse(raw, out var value) ? value : fallback;
+    }
+}

--- a/KindleMate2.Infrastructure/Repositories/KM2DB/OriginalClippingLineRepository.cs
+++ b/KindleMate2.Infrastructure/Repositories/KM2DB/OriginalClippingLineRepository.cs
@@ -137,7 +137,7 @@ namespace KindleMate2.Infrastructure.Repositories.KM2DB {
             using var transaction = connection.BeginTransaction();
 
             foreach (OriginalClippingLine originalClippingLine in listOriginalClippings) {
-                var cmd = new SqliteCommand("INSERT INTO original_clipping_lines (key, line1, line2, line3, line4, line5) VALUES (@key, @line1, @line2, @line3, @line4, @line5)", connection);
+                var cmd = new SqliteCommand("INSERT INTO original_clipping_lines (key, line1, line2, line3, line4, line5) VALUES (@key, @line1, @line2, @line3, @line4, @line5)", connection, transaction);
                 cmd.Parameters.AddWithValue("@key", originalClippingLine.Key ?? throw new InvalidOperationException());
                 cmd.Parameters.AddWithValue("@line1", originalClippingLine.Line1 ?? (object)DBNull.Value);
                 cmd.Parameters.AddWithValue("@line2", originalClippingLine.Line2 ?? (object)DBNull.Value);

--- a/KindleMate2.Shared/Strings.Designer.cs
+++ b/KindleMate2.Shared/Strings.Designer.cs
@@ -736,6 +736,33 @@ namespace KindleMate2.Shared {
         }
         
         /// <summary>
+        ///   查找类似 导入KMate数据库 的本地化字符串。
+        /// </summary>
+        public static string Import_KMate_Database {
+            get {
+                return ResourceManager.GetString("Import_KMate_Database", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 导入KMate数据库文件 的本地化字符串。
+        /// </summary>
+        public static string Import_KMate_Database_File {
+            get {
+                return ResourceManager.GetString("Import_KMate_Database_File", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 KMate数据库文件 的本地化字符串。
+        /// </summary>
+        public static string KMate_Database_File {
+            get {
+                return ResourceManager.GetString("KMate_Database_File", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 导入Kindle生词本文件 的本地化字符串。
         /// </summary>
         public static string Import_Kindle_Vocab_File {

--- a/KindleMate2.Shared/Strings.en.resx
+++ b/KindleMate2.Shared/Strings.en.resx
@@ -270,6 +270,15 @@
   <data name="Import_Kindle_Mate_Database_File" xml:space="preserve">
     <value>Import Kindle Mate's Database File</value>
   </data>
+  <data name="Import_KMate_Database" xml:space="preserve">
+    <value>Import KMate Database</value>
+  </data>
+  <data name="Import_KMate_Database_File" xml:space="preserve">
+    <value>Import KMate Database File</value>
+  </data>
+  <data name="KMate_Database_File" xml:space="preserve">
+    <value>KMate Database File</value>
+  </data>
   <data name="Confirm_Delete_Selected_Clippings" xml:space="preserve">
     <value>Are you sure you want to delete the selected clipping(s)?</value>
   </data>

--- a/KindleMate2.Shared/Strings.resx
+++ b/KindleMate2.Shared/Strings.resx
@@ -270,6 +270,15 @@
   <data name="Import_Kindle_Mate_Database_File" xml:space="preserve">
     <value>导入Kindle Mate数据库文件</value>
   </data>
+  <data name="Import_KMate_Database" xml:space="preserve">
+    <value>导入KMate数据库</value>
+  </data>
+  <data name="Import_KMate_Database_File" xml:space="preserve">
+    <value>导入KMate数据库文件</value>
+  </data>
+  <data name="KMate_Database_File" xml:space="preserve">
+    <value>KMate数据库文件</value>
+  </data>
   <data name="Confirm_Delete_Selected_Clippings" xml:space="preserve">
     <value>确认要删除选中的标注吗？</value>
   </data>

--- a/KindleMate2.Shared/Strings.zh-hans.resx
+++ b/KindleMate2.Shared/Strings.zh-hans.resx
@@ -270,6 +270,15 @@
   <data name="Import_Kindle_Mate_Database_File" xml:space="preserve">
     <value>导入Kindle Mate数据库文件</value>
   </data>
+  <data name="Import_KMate_Database" xml:space="preserve">
+    <value>导入KMate数据库</value>
+  </data>
+  <data name="Import_KMate_Database_File" xml:space="preserve">
+    <value>导入KMate数据库文件</value>
+  </data>
+  <data name="KMate_Database_File" xml:space="preserve">
+    <value>KMate数据库文件</value>
+  </data>
   <data name="Confirm_Delete_Selected_Clippings" xml:space="preserve">
     <value>确认要删除选中的标注吗？</value>
   </data>

--- a/KindleMate2.Shared/Strings.zh-hant.resx
+++ b/KindleMate2.Shared/Strings.zh-hant.resx
@@ -270,6 +270,15 @@
   <data name="Import_Kindle_Mate_Database_File" xml:space="preserve">
     <value>導入Kindle Mate數據庫文件</value>
   </data>
+  <data name="Import_KMate_Database" xml:space="preserve">
+    <value>匯入KMate資料庫</value>
+  </data>
+  <data name="Import_KMate_Database_File" xml:space="preserve">
+    <value>匯入KMate資料庫檔案</value>
+  </data>
+  <data name="KMate_Database_File" xml:space="preserve">
+    <value>KMate資料庫檔案</value>
+  </data>
   <data name="Confirm_Delete_Selected_Clippings" xml:space="preserve">
     <value>確認要刪除選中的標註嗎？</value>
   </data>

--- a/KindleMate2.Tests/DataLayerFixTests.cs
+++ b/KindleMate2.Tests/DataLayerFixTests.cs
@@ -123,4 +123,38 @@ public sealed class DataLayerFixTests : IDisposable {
         Assert.True(svc.ImportFromKmDatabase());
         Assert.Single(targetClipRepo.GetAll());
     }
+
+    [Fact]
+    public void KmDatabaseServiceImport_CrossBookSameContent_KeepsBothRows() {
+        // Regression for the unified dedup scope (KmateDedup): the legacy import must behave like the
+        // km3 import — identical content in TWO different books are two distinct highlights.
+        var targetDb = NewDb("t6-target.db");
+        var kmDb = NewDb("t6-km.db");
+
+        using (var conn = new SqliteConnection(DatabaseHelper.GetConnectionString(kmDb))) {
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                "INSERT INTO clippings (key, content, bookname, authorname, clippingdate) VALUES " +
+                "('k1', 'a shared quote', 'Book A', 'Author A', '2026-01-01 00:00:00'), " +
+                "('k2', 'a shared quote', 'Book B', 'Author B', '2026-01-02 00:00:00');";
+            cmd.ExecuteNonQuery();
+        }
+
+        var targetClipRepo = new ClippingRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var svc = new KmDatabaseService(
+            targetClipRepo,
+            new LookupRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            new SettingRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            new VocabRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            new ClippingRepository(DatabaseHelper.GetConnectionString(kmDb)),
+            new LookupRepository(DatabaseHelper.GetConnectionString(kmDb)),
+            new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(kmDb)),
+            new SettingRepository(DatabaseHelper.GetConnectionString(kmDb)),
+            new VocabRepository(DatabaseHelper.GetConnectionString(kmDb)));
+
+        Assert.True(svc.ImportFromKmDatabase());
+        Assert.Equal(2, targetClipRepo.GetAll().Count); // cross-book same content kept
+    }
 }

--- a/KindleMate2.Tests/KmateImportTests.cs
+++ b/KindleMate2.Tests/KmateImportTests.cs
@@ -1,0 +1,158 @@
+using Microsoft.Data.Sqlite;
+using Xunit;
+using KindleMate2.Application.Services.KM2DB;
+using KindleMate2.Infrastructure.Helpers;
+using KindleMate2.Infrastructure.Repositories.KM2DB;
+
+namespace KindleMate2.Tests;
+
+/// <summary>
+/// Tests for importing a KMate (kmate.io) km3.dat database into the current KM2 database
+/// via <see cref="KmateDatabaseService"/> / <see cref="KmateSourceReader"/>.
+/// The km3 source database is synthesized with its real-world schema shape
+/// (extra columns, INTEGER vocab.id, TEXT colorRGB, no settings table).
+/// </summary>
+public sealed class KmateImportTests : IDisposable {
+    private readonly string _dir;
+
+    public KmateImportTests() {
+        _dir = Path.Combine(Path.GetTempPath(), "kmate-import-tests-" + Guid.NewGuid().ToString("N")[..10]);
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose() {
+        try { Directory.Delete(_dir, true); } catch { /* best effort */ }
+    }
+
+    private string NewDb(string name) {
+        var path = Path.Combine(_dir, name);
+        Assert.True(DatabaseHelper.CreateDatabase(path, out var ex), "CreateDatabase failed: " + ex.Message);
+        return path;
+    }
+
+    /// <summary>Creates an empty KMate-shaped km3 database and returns its path.</summary>
+    private string NewKmateDb(string name) {
+        var path = Path.Combine(_dir, name);
+        using (var conn = new SqliteConnection($"Data Source={path};Mode=ReadWriteCreate;")) {
+            conn.Open();
+            foreach (var ddl in KmateSampleDdl) {
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = ddl;
+                cmd.ExecuteNonQuery();
+            }
+        }
+        return path;
+    }
+
+    private static readonly string[] KmateSampleDdl = [
+        """
+        CREATE TABLE clippings (
+            key TEXT PRIMARY KEY, content TEXT, bookname TEXT, authorname TEXT,
+            brieftype INTEGER, clippingdate TEXT, read INT DEFAULT 0, tag TEXT,
+            sync INT DEFAULT 0, newbookname TEXT, colorRGB TEXT DEFAULT '',
+            pagenumber INT DEFAULT 0, source TEXT DEFAULT 'Kindle',
+            note_parent_key TEXT, ck_synced INT DEFAULT 0, created_at TEXT, updated_at TEXT)
+        """,
+        """
+        CREATE TABLE original_clipping_lines (
+            key TEXT PRIMARY KEY, line1 TEXT, line2 TEXT, line3 TEXT, line4 TEXT, line5 TEXT,
+            created_at TEXT, updated_at TEXT)
+        """,
+        """
+        CREATE TABLE lookups (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, word_key TEXT, usage TEXT, title TEXT,
+            authors TEXT, timestamp TEXT, ck_synced INT DEFAULT 0)
+        """,
+        """
+        CREATE TABLE vocab (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, word_key TEXT, word TEXT, stem TEXT,
+            category INTEGER DEFAULT 0, translation TEXT, translation_plain TEXT,
+            dict_source TEXT, timestamp TEXT, frequency INT DEFAULT 0, sync INT DEFAULT 0,
+            ck_synced INT DEFAULT 0, colorRGB TEXT DEFAULT '', last_reviewed TEXT,
+            review_count INT DEFAULT 0, word_level INT DEFAULT 0, created_at TEXT, updated_at TEXT)
+        """,
+        "CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT, author TEXT)",
+        "CREATE TABLE tags_clippings (id INTEGER PRIMARY KEY, name TEXT)",
+        "CREATE TABLE pending_deletions (record_name TEXT PRIMARY KEY, record_type TEXT)"
+    ];
+
+    private static void Execute(SqliteConnection conn, string sql) {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    [Fact]
+    public void ImportKmateDatabase_MapsClippingsLinesLookupsVocab_AndSkipsOrphansAndEmptyContent() {
+        var targetDb = NewDb("kt-target.db");
+        var kmateDb = NewKmateDb("kt-kmate.db");
+
+        using (var conn = new SqliteConnection($"Data Source={kmateDb};Mode=ReadWrite;")) {
+            conn.Open();
+            // Two valid clippings (highlight + note) with matching raw lines…
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, colorRGB, pagenumber, source) VALUES ('a1b2c3d4e5f60718293a4b5c6d7e8f90', 'first highlight', 'Book A', 'Author A', 0, '2026-08-20 10:00:00', '', 12, 'Kindle')");
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, colorRGB, pagenumber, source) VALUES ('b2c3d4e5f60718293a4b5c6d7e8f90a1', 'a note text', 'Book A', 'Author A', 1, '2026-08-20 10:05:00', '', 12, 'Kindle')");
+            // …an empty-content row (skipped by the service)…
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, brieftype, clippingdate, source) VALUES ('c3d4e5f60718293a4b5c6d7e8f90a1b2', '', 'Book A', 0, '2026-08-20 10:10:00', 'Kindle')");
+            // …one orphan line whose key no longer exists in clippings (KMate cleanup residue)…
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('ffffffffffffffffffffffffffffffff', 'orphan line')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1, line2, line3) VALUES ('a1b2c3d4e5f60718293a4b5c6d7e8f90', 'Book A (Author A)', '', 'first highlight')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('b2c3d4e5f60718293a4b5c6d7e8f90a1', 'Book A (Author A)')");
+            // lookups (zh: prefix on word_key) and vocab (INTEGER id identity)
+            Execute(conn, "INSERT INTO lookups (word_key, usage, title, authors, timestamp) VALUES ('zh:测试', 'usage one', 'Book A', 'Author A', '2026-08-20 10:00:00')");
+            Execute(conn, "INSERT INTO lookups (word_key, usage, title, authors, timestamp) VALUES ('en:apple', 'usage two', 'Book A', 'Author A', '2026-08-20 10:01:00')");
+            Execute(conn, "INSERT INTO vocab (word_key, word, stem, category, translation, timestamp, frequency, colorRGB) VALUES ('zh:测试', '测试', '测', 0, 'test', '2026-08-20 10:00:00', 1, '-1')");
+            Execute(conn, "INSERT INTO vocab (word_key, word, stem, category, translation, timestamp, frequency, colorRGB) VALUES ('en:apple', 'apple', 'appl', 0, '', '2026-08-20 10:01:00', 2, '')");
+        }
+
+        var targetClipRepo = new ClippingRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var targetLineRepo = new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var targetLookupRepo = new LookupRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var targetVocabRepo = new VocabRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var svc = new KmateDatabaseService(targetClipRepo, targetLookupRepo, targetLineRepo, targetVocabRepo, kmateDb);
+
+        Assert.True(svc.ImportFromKmateDatabase(), "import should succeed");
+
+        Assert.Equal(2, targetClipRepo.GetAll().Count); // empty-content row skipped
+        Assert.Equal(2, targetLineRepo.GetAllKeys().Count); // orphan line filtered
+        Assert.Equal(2, targetLookupRepo.GetAll().Count);
+        Assert.Equal(2, targetVocabRepo.GetAll().Count);
+
+        // vocab id must be the word_key-derived TEXT id, not the source INTEGER id
+        Assert.NotNull(targetVocabRepo.GetAll().SingleOrDefault(v => v.Id == "zh:测试"));
+        Assert.NotNull(targetVocabRepo.GetAll().SingleOrDefault(v => v.Id == "en:apple"));
+        // colorRGB/category normalization applied
+        var apple = targetVocabRepo.GetAll().Single(v => v.Id == "en:apple");
+        Assert.Equal(-1L, apple.ColorRgb);
+    }
+
+    [Fact]
+    public void ImportKmateDatabase_SecondRun_IsIdempotent() {
+        var targetDb = NewDb("kt-target2.db");
+        var kmateDb = NewKmateDb("kt-kmate2.db");
+
+        using (var conn = new SqliteConnection($"Data Source={kmateDb};Mode=ReadWrite;")) {
+            conn.Open();
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, source) VALUES ('11112222333344445555666677778888', 'same highlight', 'Book X', 'Author X', 0, '2026-08-21 09:00:00', 'Kindle')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('11112222333344445555666677778888', 'Book X (Author X)')");
+            Execute(conn, "INSERT INTO lookups (word_key, usage, title, timestamp) VALUES ('en:word', 'usage', 'Book X', '2026-08-21 09:00:00')");
+            Execute(conn, "INSERT INTO vocab (word_key, word, translation, timestamp, frequency) VALUES ('en:word', 'word', '', '2026-08-21 09:00:00', 1)");
+        }
+
+        var clipRepo = new ClippingRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var lineRepo = new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var lookupRepo = new LookupRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var vocabRepo = new VocabRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var svc = new KmateDatabaseService(clipRepo, lookupRepo, lineRepo, vocabRepo, kmateDb);
+
+        Assert.True(svc.ImportFromKmateDatabase());
+        Assert.Single(clipRepo.GetAll());
+        Assert.Single(vocabRepo.GetAll());
+
+        Assert.True(svc.ImportFromKmateDatabase());
+        Assert.Single(clipRepo.GetAll());
+        Assert.Single(lineRepo.GetAllKeys());
+        Assert.Single(lookupRepo.GetAll());
+        Assert.Single(vocabRepo.GetAll());
+    }
+}

--- a/KindleMate2.Tests/KmateImportTests.cs
+++ b/KindleMate2.Tests/KmateImportTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.Sqlite;
 using Xunit;
 using KindleMate2.Application.Services.KM2DB;
+using KindleMate2.Domain.Entities.KM2DB;
 using KindleMate2.Infrastructure.Helpers;
 using KindleMate2.Infrastructure.Repositories.KM2DB;
 
@@ -109,7 +110,7 @@ public sealed class KmateImportTests : IDisposable {
         var targetLineRepo = new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(targetDb));
         var targetLookupRepo = new LookupRepository(DatabaseHelper.GetConnectionString(targetDb));
         var targetVocabRepo = new VocabRepository(DatabaseHelper.GetConnectionString(targetDb));
-        var svc = new KmateDatabaseService(targetClipRepo, targetLookupRepo, targetLineRepo, targetVocabRepo, kmateDb);
+        var svc = new KmateDatabaseService(targetClipRepo, targetLookupRepo, targetLineRepo, targetVocabRepo, kmateDb, DatabaseHelper.GetConnectionString(targetDb));
 
         Assert.True(svc.ImportFromKmateDatabase(), "import should succeed");
 
@@ -150,7 +151,8 @@ public sealed class KmateImportTests : IDisposable {
             new LookupRepository(DatabaseHelper.GetConnectionString(targetDb)),
             lineRepo,
             new VocabRepository(DatabaseHelper.GetConnectionString(targetDb)),
-            kmateDb);
+            kmateDb,
+            DatabaseHelper.GetConnectionString(targetDb));
 
         Assert.True(svc.ImportFromKmateDatabase());
         Assert.Equal(3, clipRepo.GetAll().Count); // cross-book same content kept (2) + unique (1)
@@ -177,7 +179,7 @@ public sealed class KmateImportTests : IDisposable {
         var lineRepo = new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(targetDb));
         var lookupRepo = new LookupRepository(DatabaseHelper.GetConnectionString(targetDb));
         var vocabRepo = new VocabRepository(DatabaseHelper.GetConnectionString(targetDb));
-        var svc = new KmateDatabaseService(clipRepo, lookupRepo, lineRepo, vocabRepo, kmateDb);
+        var svc = new KmateDatabaseService(clipRepo, lookupRepo, lineRepo, vocabRepo, kmateDb, DatabaseHelper.GetConnectionString(targetDb));
 
         Assert.True(svc.ImportFromKmateDatabase());
         Assert.Single(clipRepo.GetAll());
@@ -188,5 +190,36 @@ public sealed class KmateImportTests : IDisposable {
         Assert.Single(lineRepo.GetAllKeys());
         Assert.Single(lookupRepo.GetAll());
         Assert.Single(vocabRepo.GetAll());
+    }
+
+    [Fact]
+    public void KmateAtomicWriter_ConflictRollsBackAllTables() {
+        var targetDb = NewDb("kt-atomic.db");
+        var targetConn = DatabaseHelper.GetConnectionString(targetDb);
+        var clipRepo = new ClippingRepository(targetConn);
+        var vocabRepo = new VocabRepository(targetConn);
+
+        // Pre-existing row whose key collides with one of the incoming candidates.
+        var existing = new Vocab { Id = "en:dup", Word = "dup", WordKey = "en:dup" };
+        Assert.True(vocabRepo.Add(existing));
+
+        var conflictVocab = new Vocab { Id = "en:dup", Word = "dup-2", WordKey = "en:dup" };
+        var goodClipping = new Clipping {
+            Key = "dddd1111222233334444555566667777",
+            Content = "a highlight",
+            BookName = "Atomic Book",
+            AuthorName = "Author"
+        };
+
+        // The vocab insert conflicts -> whole batch must roll back, including clippings.
+        Assert.ThrowsAny<Exception>(() => KmateAtomicWriter.WriteAll(
+            targetConn,
+            new[] { goodClipping },
+            Array.Empty<OriginalClippingLine>(),
+            Array.Empty<Lookup>(),
+            new[] { conflictVocab }));
+
+        Assert.Empty(clipRepo.GetAll());
+        Assert.Single(vocabRepo.GetAll()); // only the pre-existing row remains
     }
 }

--- a/KindleMate2.Tests/KmateImportTests.cs
+++ b/KindleMate2.Tests/KmateImportTests.cs
@@ -127,6 +127,40 @@ public sealed class KmateImportTests : IDisposable {
     }
 
     [Fact]
+    public void ImportKmateDatabase_CrossBookSameContent_KeepsBothRows() {
+        var targetDb = NewDb("kt-crossbook.db");
+        var kmateDb = NewKmateDb("kt-crossbook-kmate.db");
+
+        using (var conn = new SqliteConnection($"Data Source={kmateDb};Mode=ReadWrite;")) {
+            conn.Open();
+            // Identical sentence highlighted in TWO different books: both are distinct highlights
+            // and must be kept (dedup scope is per book+author+content, not global content).
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, source) VALUES ('aaaa1111222233334444555566667777', 'a shared quote', 'Book A', 'Author A', 0, '2026-08-21 09:00:00', 'Kindle')");
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, source) VALUES ('bbbb1111222233334444555566667777', 'a shared quote', 'Book B', 'Author B', 0, '2026-08-21 09:00:05', 'Kindle')");
+            // …and a genuine duplicate within the SAME book (same key, same content) stays skipped.
+            Execute(conn, "INSERT INTO clippings (key, content, bookname, authorname, brieftype, clippingdate, source) VALUES ('cccc1111222233334444555566667777', 'unique line', 'Book A', 'Author A', 0, '2026-08-21 09:00:10', 'Kindle')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('aaaa1111222233334444555566667777', 'Book A (Author A)')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('bbbb1111222233334444555566667777', 'Book B (Author B)')");
+            Execute(conn, "INSERT INTO original_clipping_lines (key, line1) VALUES ('cccc1111222233334444555566667777', 'Book A (Author A)')");
+        }
+
+        var clipRepo = new ClippingRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var lineRepo = new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var svc = new KmateDatabaseService(clipRepo,
+            new LookupRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            lineRepo,
+            new VocabRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            kmateDb);
+
+        Assert.True(svc.ImportFromKmateDatabase());
+        Assert.Equal(3, clipRepo.GetAll().Count); // cross-book same content kept (2) + unique (1)
+        Assert.Equal(3, lineRepo.GetAllKeys().Count);
+
+        Assert.True(svc.ImportFromKmateDatabase()); // idempotent
+        Assert.Equal(3, clipRepo.GetAll().Count);
+    }
+
+    [Fact]
     public void ImportKmateDatabase_SecondRun_IsIdempotent() {
         var targetDb = NewDb("kt-target2.db");
         var kmateDb = NewKmateDb("kt-kmate2.db");

--- a/KindleMate2/FrmMain.Designer.cs
+++ b/KindleMate2/FrmMain.Designer.cs
@@ -43,6 +43,7 @@ namespace KindleMate2 {
             menuImportKindle = new ToolStripMenuItem();
             menuImportKindleWords = new ToolStripMenuItem();
             menuImportKindleMate = new ToolStripMenuItem();
+            menuImportKmateDatabase = new ToolStripMenuItem();
             menuSyncFromKindle = new ToolStripMenuItem();
             menuSyncToKindle = new ToolStripMenuItem();
             menuExportMd = new ToolStripMenuItem();
@@ -186,7 +187,7 @@ namespace KindleMate2 {
             // 
             // menuManage
             // 
-            menuManage.DropDownItems.AddRange(new ToolStripItem[] { menuImportKindle, menuImportKindleWords, menuImportKindleMate, menuSyncFromKindle, menuSyncToKindle, menuExportMd, menuClean, menuRebuild, menuBackup, menuClear });
+            menuManage.DropDownItems.AddRange(new ToolStripItem[] { menuImportKindle, menuImportKindleWords, menuImportKindleMate, menuImportKmateDatabase, menuSyncFromKindle, menuSyncToKindle, menuExportMd, menuClean, menuRebuild, menuBackup, menuClear });
             menuManage.Name = "menuManage";
             menuManage.Size = new Size(107, 36);
             menuManage.Text = "管理(&M)";
@@ -214,6 +215,14 @@ namespace KindleMate2 {
             menuImportKindleMate.Size = new Size(360, 44);
             menuImportKindleMate.Text = "导入Kindle Mate数据库";
             menuImportKindleMate.Click += MenuImportKindleMate_Click;
+            // 
+            // menuImportKmateDatabase
+            // 
+            menuImportKmateDatabase.Image = Resources.page_facing_up;
+            menuImportKmateDatabase.Name = "menuImportKmateDatabase";
+            menuImportKmateDatabase.Size = new Size(360, 44);
+            menuImportKmateDatabase.Text = "导入KMate数据库";
+            menuImportKmateDatabase.Click += MenuImportKmateDatabase_Click;
             // 
             // menuSyncFromKindle
             // 
@@ -1007,6 +1016,7 @@ namespace KindleMate2 {
         private ToolStripMenuItem menuManage;
         private ToolStripMenuItem menuBackup;
         private ToolStripMenuItem menuImportKindleMate;
+        private ToolStripMenuItem menuImportKmateDatabase;
         private ToolStripMenuItem menuSyncFromKindle;
         private ToolStripMenuItem menuImportKindle;
         private ToolStripMenuItem menuRefresh;

--- a/KindleMate2/FrmMain.cs
+++ b/KindleMate2/FrmMain.cs
@@ -198,6 +198,7 @@ namespace KindleMate2 {
             menuImportKindle.Text = Strings.Import_Kindle_Clippings;
             menuImportKindleWords.Text = Strings.Import_Kindle_Vocabs;
             menuImportKindleMate.Text = Strings.Import_Kindle_Mate_Database;
+            menuImportKmateDatabase.Text = Strings.Import_KMate_Database;
             menuSyncFromKindle.Text = Strings.Import_Kindle_Clippings_From_Kindle;
             menuSyncToKindle.Text = Strings.Sync_To_Kindle;
             menuExportMd.Text = Strings.Export_To_Markdown;
@@ -1183,6 +1184,20 @@ namespace KindleMate2 {
 
             RunBackgroundTask(
                 () => _importManager.ImportKmDatabase(fileDialog.FileName),
+                Strings.Successful, Strings.Import_Failed);
+        }
+
+        private void MenuImportKmateDatabase_Click(object sender, EventArgs e) {
+            var fileDialog = new OpenFileDialog {
+                Title = Strings.Import_KMate_Database_File + Strings.Space + @"(km3.dat)",
+                CheckFileExists = true, CheckPathExists = true, DefaultExt = "dat",
+                Filter = Strings.KMate_Database_File + Strings.Space + @"(*.dat)|*.dat",
+                FilterIndex = 2, RestoreDirectory = true, ReadOnlyChecked = true, ShowReadOnly = true
+            };
+            if (fileDialog.ShowDialog() != DialogResult.OK) return;
+
+            RunBackgroundTask(
+                () => _importManager.ImportKmateDatabase(fileDialog.FileName),
                 Strings.Successful, Strings.Import_Failed);
         }
 

--- a/README.en.md
+++ b/README.en.md
@@ -41,6 +41,7 @@
 
 - [x] Import Highlights (`My Clippings.txt`)
 - [x] Import Vocabulary List (`vocab.db`)
+- [x] Import KMate Database (`km3.dat`)
 - [x] Sync Connected Kindle Devices
 - [x] Edit Highlights
 - [x] Edit Vocabulary List

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 
 - [x] 导入标注（`My Clippings.txt`）
 - [x] 导入生词本（`vocab.db`）
+- [x] 导入 KMate 数据库（`km3.dat`）
 - [x] 同步已连接的Kindle设备
 - [x] 编辑标注
 - [x] 编辑生词本


### PR DESCRIPTION
新增对 KMate 数据库 `km3.dat` 的导入支持,实现 1:1 忠实迁移。管理菜单新增「导入KMate数据库」(中/英/繁 4 语言资源)。