### PR TITLE
feat: My Clippings 解析多语言化(类型标签 + 日期,设备语言全集 + 真实样本校准)

### DIFF
--- a/KindleMate2.Application/Services/KM2DB/KM2DatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KM2DatabaseService.cs
@@ -187,27 +187,13 @@ namespace KindleMate2.Application.Services.KM2DB {
                     clipping.PageNumber = pageNumber;
                     clipping.ClippingTypeLocation = clippingTypeLocation;
 
-                    string clippingDate;
+                    // 多语言日期解析(MyClippingsHelper.TryParseClippingDate):清洗前缀/星期词 →
+                    // 原有三种精确格式优先(零回归)→ 11 个 Kindle 文化轮询兜底(原版 Kindle Mate 做法)。
                     var metaSplit = metadata.Split('|');
-                    var datetime = metaSplit[^1].Replace("Added on", "").Replace("添加于", "").Trim();
-                    datetime = datetime[(datetime.IndexOf(',') + 1)..].Trim();
-                    var isDateParsed = DateTime.TryParseExact(datetime, "MMMM d, yyyy h:m:s tt", CultureInfo.GetCultureInfo("en-US"), DateTimeStyles.None, out DateTime parsedDate);
-                    if (!isDateParsed) {
-                        // Try English format with day before month (e.g., "19 May 2025 22:06:02")
-                        isDateParsed = DateTime.TryParseExact(datetime, "d MMMM yyyy HH:mm:ss", CultureInfo.GetCultureInfo("en-US"), DateTimeStyles.None, out parsedDate);
-                    }
-                    if (!isDateParsed) {
-                        var dayOfWeekIndex = datetime.IndexOf("星期", StringComparison.Ordinal);
-                        if (dayOfWeekIndex != -1) {
-                            datetime = datetime.Remove(dayOfWeekIndex, 3);
-                        }
-                        isDateParsed = DateTime.TryParseExact(datetime, "yyyy年M月d日 tth:m:s", CultureInfo.GetCultureInfo("zh-CN"), DateTimeStyles.None, out parsedDate);
-                    }
-                    if (isDateParsed && parsedDate != DateTime.MinValue) {
-                        clippingDate = parsedDate.ToString("yyyy-MM-dd HH:mm:ss");
-                    } else {
+                    if (!MyClippingsHelper.TryParseClippingDate(metaSplit[^1], out var parsedDate)) {
                         continue;
                     }
+                    var clippingDate = parsedDate.ToString("yyyy-MM-dd HH:mm:ss");
                     clipping.ClippingDate = clippingDate;
 
                     var key = clippingDate + "|" + clippingTypeLocation;

--- a/KindleMate2.Application/Services/KM2DB/KM2DatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KM2DatabaseService.cs
@@ -59,11 +59,14 @@ namespace KindleMate2.Application.Services.KM2DB {
                     });
                 }
 
-                var insertedCount = HandleClippings(myClippings);
+                var insertedCount = HandleClippings(myClippings, out var skipCounts);
 
                 result = new Dictionary<string, string> {
                     { AppConstants.ParsedCount, delimiterIndex.Count.ToString() },
-                    { AppConstants.InsertedCount, insertedCount.ToString() }
+                    { AppConstants.InsertedCount, insertedCount.ToString() },
+                    { AppConstants.SkippedDateCount, skipCounts.DateFailed.ToString() },
+                    { AppConstants.SkippedPageCount, skipCounts.PageFailed.ToString() },
+                    { AppConstants.SkippedLimitCount, skipCounts.LimitReached.ToString() }
                 };
                 return true;
             } catch (Exception e) {
@@ -98,7 +101,7 @@ namespace KindleMate2.Application.Services.KM2DB {
                         Delimiter = line5
                     }).ToList();
 
-                var insertedCount = HandleClippings(myClippings, isRebuild: true);
+                var insertedCount = HandleClippings(myClippings, out _, isRebuild: true);
 
                 UpdateFrequency();
 
@@ -116,7 +119,14 @@ namespace KindleMate2.Application.Services.KM2DB {
             }
         }
 
-        private int HandleClippings(List<MyClipping> clippings, bool isRebuild = false) {
+        private sealed class SkipCounts {
+            public int LimitReached;
+            public int PageFailed;
+            public int DateFailed;
+        }
+
+        private int HandleClippings(List<MyClipping> clippings, out SkipCounts skipCounts, bool isRebuild = false) {
+            skipCounts = new SkipCounts();
             var insertResult = 0;
 
             var allClippings = clippingRepository.GetAll();
@@ -141,7 +151,11 @@ namespace KindleMate2.Application.Services.KM2DB {
                     var metadata = myClipping.Metadata;
                     var content = myClipping.Content;
 
-                    if (string.IsNullOrWhiteSpace(content) || MyClippingsHelper.IsClippingLimitReached(content)) {
+                    if (string.IsNullOrWhiteSpace(content)) {
+                        continue;
+                    }
+                    if (MyClippingsHelper.IsClippingLimitReached(content)) {
+                        skipCounts.LimitReached++;
                         continue;
                     }
 
@@ -182,6 +196,7 @@ namespace KindleMate2.Application.Services.KM2DB {
                         isPageParsed = int.TryParse(strMatched, out pageNumber);
                     }
                     if (!isPageParsed || pageNumber == -1 || pageNumber == 0) {
+                        skipCounts.PageFailed++;
                         continue;
                     }
                     clipping.PageNumber = pageNumber;
@@ -191,6 +206,7 @@ namespace KindleMate2.Application.Services.KM2DB {
                     // 原有三种精确格式优先(零回归)→ 11 个 Kindle 文化轮询兜底(原版 Kindle Mate 做法)。
                     var metaSplit = metadata.Split('|');
                     if (!MyClippingsHelper.TryParseClippingDate(metaSplit[^1], out var parsedDate)) {
+                        skipCounts.DateFailed++;
                         continue;
                     }
                     var clippingDate = parsedDate.ToString("yyyy-MM-dd HH:mm:ss");

--- a/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
+++ b/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
@@ -177,6 +177,8 @@ namespace KindleMate2.Infrastructure.Helpers {
             "Añadido el ", "Ajouté le ", "Ajouté ll ",
             "日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日",
             "Dodany w dn. ", "Toegevoegd op ", "à",
+            // 意/葡真实前缀(KindleToJoplin languages.ts example: "Aggiunto il domenica…" / "Adicionado em domingo…")
+            "Aggiunto il ", "Adicionado em ",
             // 德语时间短语(真实样本 "…4.46 Uhr GMT+07:29" / "…um 01:31:13 Uhr",SuzanaK·becausecurious 公开样本)。
             // 注意:删除 token 若含两侧空格会把词前后空格一并吃掉导致粘连("2012 um 01"→"201201"),
             // 故 "um " 只带单侧空格,清理后再折叠空白。

--- a/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
+++ b/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
@@ -164,6 +164,97 @@ namespace KindleMate2.Infrastructure.Helpers {
             return BriefType.Unknown;
         }
 
+        // ── 多语言日期解析(对齐原版 Kindle Mate 1.38 的 getLine2TypeLocationAddingTime) ──
+
+        /// <summary>
+        /// 各区域 Kindle 日期行中的前缀/星期/冗余词,解析前逐项删除(原版 StringToDelete 25 项;
+        /// 另补德语 Hinzugefügt 的变体与俄语日期常用词,删除均忽略大小写)。
+        /// </summary>
+        private static readonly string[] KindleDateCleaningTokens = [
+            "星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日",
+            "Added on ", "添加于", "已添加至",
+            "Hinzugefügt am ", "Hinzugefügt pm ", "作成日: ",
+            "Añadido el ", "Ajouté le ", "Ajouté ll ",
+            "日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日",
+            "Dodany w dn. ", "Toegevoegd op ", "à",
+            // 各语言星期词(.NET DateTime.TryParse 对带星期前缀的非标准串并不宽松 → 一并删除)
+            "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+            "Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag",
+            "dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi",
+            "domingo", "lunes", "martes", "miércoles", "jueves", "viernes", "sábado",
+            "domenica", "lunedì", "martedì", "mercoledì", "giovedì", "venerdì", "sabato",
+            "zondag", "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag",
+            "niedzielę", "niedziela", "poniedziałek", "wtorek", "środa", "czwartek", "piątek", "sobota"
+        ];
+
+        /// <summary>Kindle 设备区域文化(原版 10 个 + ru-RU),用于轮询解析。</summary>
+        private static readonly string[] KindleDateCultures = [
+            "zh-CN", "en-US", "ja-JP", "pl-PL", "de-DE", "fr-FR", "es-ES", "it-IT", "pt-PT", "nl-NL", "ru-RU"
+        ];
+
+        private static readonly CultureInfo EnUs = CultureInfo.GetCultureInfo("en-US");
+        private static readonly CultureInfo ZhCn = CultureInfo.GetCultureInfo("zh-CN");
+
+        /// <summary>
+        /// 解析 Kindle 区域化的日期行(形如 "Added on Sunday, May 19, 2025, 10:20:31 PM" /
+        /// "添加于 2025年5月19日 星期一 下午10:20:31" / "作成日: 2025年5月19日 22:20:31" …)。
+        /// 策略(借鉴原版):① 清洗前缀/星期词 → ② 优先尝试原有三种精确格式(零回归)→ ③ 按 11 个
+        /// Kindle 文化逐轮 <see cref="DateTime.TryParse(string, IFormatProvider, DateTimeStyles, out DateTime)"/>
+        /// 兜底(.NET 文化规则消化各区域长/短日期变体)。输出统一由调用方格式化为 yyyy-MM-dd HH:mm:ss。
+        /// </summary>
+        public static bool TryParseClippingDate(string rawDate, out DateTime parsedDate) {
+            parsedDate = default;
+            if (string.IsNullOrWhiteSpace(rawDate)) {
+                return false;
+            }
+
+            var cleaned = rawDate;
+            foreach (var token in KindleDateCleaningTokens) {
+                cleaned = Regex.Replace(cleaned, Regex.Escape(token), string.Empty, RegexOptions.IgnoreCase);
+            }
+            // 折叠清理留下的连续空白(如 "2025 à 22" 删 à 后),避免影响解析
+            cleaned = Regex.Replace(cleaned, @"\s{2,}", " ").Trim();
+            // 某些区域在“日期 与 时间”之间带逗号(如 en/de/es "…2025, 10:20:31 PM"),文化解析不接受 → 归并为空格。
+            cleaned = Regex.Replace(cleaned, @",\s+(?=\d{1,2}:\d{2})", " ");
+            var gmtIndex = cleaned.LastIndexOf(" GMT", StringComparison.OrdinalIgnoreCase);
+            if (gmtIndex >= 0) {
+                cleaned = cleaned[..gmtIndex].Trim();
+            }
+
+            // 与原实现一致的“去掉首逗号前段”变体(兼容 "Added on Sunday, …" 类前缀残留)
+            var truncated = cleaned;
+            var firstComma = cleaned.IndexOf(',');
+            if (firstComma >= 0) {
+                truncated = cleaned[(firstComma + 1)..].Trim();
+            }
+
+            if (TryParseExactKindleDate(truncated, out parsedDate) || TryParseExactKindleDate(cleaned, out parsedDate)) {
+                return true;
+            }
+
+            foreach (var cultureName in KindleDateCultures) {
+                var culture = CultureInfo.GetCultureInfo(cultureName);
+                if (DateTime.TryParse(cleaned, culture, DateTimeStyles.None, out parsedDate) ||
+                    DateTime.TryParseExact(cleaned, "d MMMM yyyy HH:mm:ss", culture, DateTimeStyles.None, out parsedDate) ||
+                    DateTime.TryParseExact(cleaned, "d MMMM yyyy H:mm:ss", culture, DateTimeStyles.None, out parsedDate)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static bool TryParseExactKindleDate(string input, out DateTime parsedDate) {
+            if (DateTime.TryParseExact(input, "MMMM d, yyyy h:m:s tt", EnUs, DateTimeStyles.None, out parsedDate) ||
+                DateTime.TryParseExact(input, "d MMMM yyyy HH:mm:ss", EnUs, DateTimeStyles.None, out parsedDate)) {
+                return true;
+            }
+            var dayOfWeekIndex = input.IndexOf("星期", StringComparison.Ordinal);
+            if (dayOfWeekIndex != -1) {
+                input = input.Remove(dayOfWeekIndex, 3);
+            }
+            return DateTime.TryParseExact(input, "yyyy年M月d日 tth:m:s", ZhCn, DateTimeStyles.None, out parsedDate);
+        }
+
         private static DateTime? ParseToUtcDate(string serializedDate) {
             if (DateTime.TryParse(serializedDate, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out DateTime date) || CultureInfoArray.Any(culture => DateTime.TryParse(serializedDate, new CultureInfo(culture), DateTimeStyles.AssumeUniversal, out date))) {
                 return date;

--- a/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
+++ b/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
@@ -177,6 +177,10 @@ namespace KindleMate2.Infrastructure.Helpers {
             "Añadido el ", "Ajouté le ", "Ajouté ll ",
             "日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日",
             "Dodany w dn. ", "Toegevoegd op ", "à",
+            // 德语时间短语(真实样本 "…4.46 Uhr GMT+07:29" / "…um 01:31:13 Uhr",SuzanaK·becausecurious 公开样本)。
+            // 注意:删除 token 若含两侧空格会把词前后空格一并吃掉导致粘连("2012 um 01"→"201201"),
+            // 故 "um " 只带单侧空格,清理后再折叠空白。
+            " Uhr", "um ",
             // 各语言星期词(.NET DateTime.TryParse 对带星期前缀的非标准串并不宽松 → 一并删除)
             "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
             "Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag",
@@ -212,14 +216,17 @@ namespace KindleMate2.Infrastructure.Helpers {
             foreach (var token in KindleDateCleaningTokens) {
                 cleaned = Regex.Replace(cleaned, Regex.Escape(token), string.Empty, RegexOptions.IgnoreCase);
             }
-            // 折叠清理留下的连续空白(如 "2025 à 22" 删 à 后),避免影响解析
-            cleaned = Regex.Replace(cleaned, @"\s{2,}", " ").Trim();
+            // 折叠清理留下的连续空白(如 "2025 à 22" 删 à 后),并去掉星期词删除后残留的行首逗号
+            // (en 真实 "Sunday, September 05, 2021…" 删 Sunday 后留 ", …"),避免影响后续解析
+            cleaned = Regex.Replace(cleaned, @"\s{2,}", " ").Trim().TrimStart(',', ' ');
             // 某些区域在“日期 与 时间”之间带逗号(如 en/de/es "…2025, 10:20:31 PM"),文化解析不接受 → 归并为空格。
             cleaned = Regex.Replace(cleaned, @",\s+(?=\d{1,2}:\d{2})", " ");
             var gmtIndex = cleaned.LastIndexOf(" GMT", StringComparison.OrdinalIgnoreCase);
             if (gmtIndex >= 0) {
                 cleaned = cleaned[..gmtIndex].Trim();
             }
+            // 德语老设备点号时间(真实样本 "4.46 Uhr" 去 Uhr/GMT 后为 "4.46")→ 归并为冒号 "4:46"
+            cleaned = Regex.Replace(cleaned, @"(?<=^|\s)(\d{1,2})\.(\d{2})(?=\s|$)", "$1:$2");
 
             // 与原实现一致的“去掉首逗号前段”变体(兼容 "Added on Sunday, …" 类前缀残留)
             var truncated = cleaned;

--- a/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
+++ b/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
@@ -194,14 +194,12 @@ namespace KindleMate2.Infrastructure.Helpers {
         ];
 
         /// <summary>
-        /// Kindle 设备区域文化,用于轮询解析。覆盖 Kindle 官方界面语言全集:
-        /// 简中/英/日/波/德/法/西/意/葡/荷/俄 + 繁中/韩/土(zh-TW/ko-KR/tr-TR 依 Kindle 语言设置补入)。
-        /// 注:zh-TW/ko-KR/tr-TR 的类型词与日期前缀暂无公开原始样本,文化兜底保证其日期行可解析
-        /// (类型词缺失仅归为 Unknown,不丢行;待真机样本补齐见 KmateDedup 注释)。
+        /// Kindle 设备区域文化(原版 Kindle Mate 10 个 + ru-RU),用于轮询解析。
+        /// 注:zh-TW / ko-KR / tr-TR 不在 Kindle 界面语言列表中,不纳入(2026-09-06 用户纠正)。
+        /// 俄语词表见于原版 modClippingsPatterns,故保留 ru-RU 兜底。
         /// </summary>
         private static readonly string[] KindleDateCultures = [
-            "zh-CN", "en-US", "ja-JP", "pl-PL", "de-DE", "fr-FR", "es-ES", "it-IT", "pt-PT", "nl-NL", "ru-RU",
-            "zh-TW", "ko-KR", "tr-TR"
+            "zh-CN", "en-US", "ja-JP", "pl-PL", "de-DE", "fr-FR", "es-ES", "it-IT", "pt-PT", "nl-NL", "ru-RU"
         ];
 
         private static readonly CultureInfo EnUs = CultureInfo.GetCultureInfo("en-US");
@@ -210,7 +208,7 @@ namespace KindleMate2.Infrastructure.Helpers {
         /// <summary>
         /// 解析 Kindle 区域化的日期行(形如 "Added on Sunday, May 19, 2025, 10:20:31 PM" /
         /// "添加于 2025年5月19日 星期一 下午10:20:31" / "作成日: 2025年5月19日 22:20:31" …)。
-        /// 策略(借鉴原版):① 清洗前缀/星期词 → ② 优先尝试原有三种精确格式(零回归)→ ③ 按 14 个
+        /// 策略(借鉴原版):① 清洗前缀/星期词 → ② 优先尝试原有三种精确格式(零回归)→ ③ 按 11 个
         /// Kindle 文化逐轮 <see cref="DateTime.TryParse(string, IFormatProvider, DateTimeStyles, out DateTime)"/>
         /// 兜底(.NET 文化规则消化各区域长/短日期变体)。输出统一由调用方格式化为 yyyy-MM-dd HH:mm:ss。
         /// </summary>

--- a/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
+++ b/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
@@ -194,12 +194,15 @@ namespace KindleMate2.Infrastructure.Helpers {
         ];
 
         /// <summary>
-        /// Kindle 设备区域文化(原版 Kindle Mate 10 个 + ru-RU),用于轮询解析。
-        /// 注:zh-TW / ko-KR / tr-TR 不在 Kindle 界面语言列表中,不纳入(2026-09-06 用户纠正)。
-        /// 俄语词表见于原版 modClippingsPatterns,故保留 ru-RU 兜底。
+        /// Kindle 日期解析文化列表(2026-09-06 定稿):
+        /// - 用户设备语言设置页(滚完)显示 11 项,全部覆盖:zh-CN / en-US / en-GB / de-DE / es-ES /
+        ///   fr-FR / it-IT / ja-JP / nl-NL / pt-BR / ru-RU;
+        /// - 其余(en-GB/pt-BR 区域变体 + pt-PT/pl-PL,原版 Kindle Mate 10 区)保留作<b>冗余</b>:
+        ///   不同 Kindle 型号/地区语言集可能更多,冗余轮询无害;
+        /// - zh-TW / ko-KR / tr-TR 未见于任何 Kindle 语言列表,不纳入。
         /// </summary>
         private static readonly string[] KindleDateCultures = [
-            "zh-CN", "en-US", "ja-JP", "pl-PL", "de-DE", "fr-FR", "es-ES", "it-IT", "pt-PT", "nl-NL", "ru-RU"
+            "zh-CN", "en-US", "en-GB", "ja-JP", "pl-PL", "de-DE", "fr-FR", "es-ES", "it-IT", "pt-BR", "pt-PT", "nl-NL", "ru-RU"
         ];
 
         private static readonly CultureInfo EnUs = CultureInfo.GetCultureInfo("en-US");

--- a/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
+++ b/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
@@ -245,19 +245,106 @@ namespace KindleMate2.Infrastructure.Helpers {
                 truncated = cleaned[(firstComma + 1)..].Trim();
             }
 
-            if (TryParseExactKindleDate(truncated, out parsedDate) || TryParseExactKindleDate(cleaned, out parsedDate)) {
+            if (TryParseExactKindleDate(truncated, out var exactDate) && IsSaneYear(exactDate)) {
+                parsedDate = exactDate;
+                return true;
+            }
+            if (TryParseExactKindleDate(cleaned, out var exactDate2) && IsSaneYear(exactDate2)) {
+                parsedDate = exactDate2;
                 return true;
             }
 
             foreach (var cultureName in KindleDateCultures) {
                 var culture = CultureInfo.GetCultureInfo(cultureName);
-                if (DateTime.TryParse(cleaned, culture, DateTimeStyles.None, out parsedDate) ||
-                    DateTime.TryParseExact(cleaned, "d MMMM yyyy HH:mm:ss", culture, DateTimeStyles.None, out parsedDate) ||
-                    DateTime.TryParseExact(cleaned, "d MMMM yyyy H:mm:ss", culture, DateTimeStyles.None, out parsedDate)) {
+                if (DateTime.TryParse(cleaned, culture, DateTimeStyles.None, out var parsed) && IsSaneYear(parsed)) {
+                    parsedDate = parsed;
+                    return true;
+                }
+                if ((DateTime.TryParseExact(cleaned, "d MMMM yyyy HH:mm:ss", culture, DateTimeStyles.None, out parsed) ||
+                     DateTime.TryParseExact(cleaned, "d MMMM yyyy H:mm:ss", culture, DateTimeStyles.None, out parsed)) && IsSaneYear(parsed)) {
+                    parsedDate = parsed;
                     return true;
                 }
             }
+
+            // 最后兜底:以上全失败时,提取串中的数字日期(yyyy-m-d / m/d/yyyy / d.m.yyyy / yyyy年m月d日)
+            // 并尝试附带时间。语言无关,可捞回文化轮询不吃但日期确实存在的行。
+            if (TryExtractNumericDate(cleaned, out var numericDate) && IsSaneYear(numericDate)) {
+                parsedDate = numericDate;
+                return true;
+            }
             return false;
+        }
+
+        /// <summary>Kindle 数据合理年份范围(1900–2100),防止宽松解析把畸形串解析成异常年份。</summary>
+        private static bool IsSaneYear(DateTime date) {
+            return date.Year is >= 1900 and <= 2100;
+        }
+
+        /// <summary>
+        /// 数字日期通用提取兜底:识别 yyyy-m-d(含中文 年月日)、m/d/yyyy、d.m.yyyy 三种形态,
+        /// 并尝试附带紧随其后的冒号时间(含 AM/PM、上午/下午)。全部失败返回 false。
+        /// </summary>
+        private static bool TryExtractNumericDate(string input, out DateTime parsedDate) {
+            parsedDate = default;
+            if (string.IsNullOrWhiteSpace(input)) {
+                return false;
+            }
+            // 1) 年在前: yyyy年m月d日 / yyyy-m-d / yyyy/m/d / yyyy.m.d
+            var ymd = Regex.Match(input, @"(?<!\d)(?<y>\d{4})[./\-年](?<m>\d{1,2})[./\-月](?<d>\d{1,2})(?!\d)");
+            Match dateMatch = ymd;
+            int? y = null, m = null, d = null;
+            if (ymd.Success) {
+                y = int.Parse(ymd.Groups["y"].Value);
+                m = int.Parse(ymd.Groups["m"].Value);
+                d = int.Parse(ymd.Groups["d"].Value);
+            } else {
+                // 2) 年在后且点/斜杠分隔,先欧式 d.m.yyyy 再美式 m/d/yyyy
+                var dmy = Regex.Match(input, @"(?<!\d)(?<d>\d{1,2})\.(?<m>\d{1,2})\.(?<y>\d{4})(?!\d)");
+                if (dmy.Success) {
+                    dateMatch = dmy;
+                    d = int.Parse(dmy.Groups["d"].Value);
+                    m = int.Parse(dmy.Groups["m"].Value);
+                    y = int.Parse(dmy.Groups["y"].Value);
+                } else {
+                    var mdy = Regex.Match(input, @"(?<!\d)(?<m>\d{1,2})[/\-](?<d>\d{1,2})[/\-](?<y>\d{4})(?!\d)");
+                    if (!mdy.Success) {
+                        return false;
+                    }
+                    dateMatch = mdy;
+                    m = int.Parse(mdy.Groups["m"].Value);
+                    d = int.Parse(mdy.Groups["d"].Value);
+                    y = int.Parse(mdy.Groups["y"].Value);
+                }
+            }
+
+            var hour = 0;
+            var minute = 0;
+            var second = 0;
+            // 时间:日期匹配之后找首个冒号时间
+            var timeMatch = Regex.Match(input, @"(?<h>\d{1,2}):(?<min>\d{2})(?::(?<s>\d{2}))?");
+            while (timeMatch.Success && timeMatch.Index < dateMatch.Index + dateMatch.Length) {
+                timeMatch = timeMatch.NextMatch();
+            }
+            if (timeMatch.Success) {
+                hour = int.Parse(timeMatch.Groups["h"].Value);
+                minute = int.Parse(timeMatch.Groups["min"].Value);
+                second = timeMatch.Groups["s"].Success ? int.Parse(timeMatch.Groups["s"].Value) : 0;
+                // 12 小时制修饰(AM/PM/上午/下午):检查时间之后一小段
+                var tail = input[timeMatch.Index..];
+                var meridian = Regex.Match(tail, @"(?i)\b(am|pm|上午|下午)\b");
+                if (meridian.Success && meridian.Index <= 12) {
+                    var isPm = meridian.Value.Equals("pm", StringComparison.OrdinalIgnoreCase) || meridian.Value.Contains("下午");
+                    hour = hour % 12 + (isPm ? 12 : 0);
+                }
+            }
+
+            try {
+                parsedDate = new DateTime(y!.Value, m!.Value, d!.Value, hour, minute, second);
+                return true;
+            } catch (ArgumentOutOfRangeException) {
+                return false;
+            }
         }
 
         private static bool TryParseExactKindleDate(string input, out DateTime parsedDate) {

--- a/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
+++ b/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
@@ -194,15 +194,16 @@ namespace KindleMate2.Infrastructure.Helpers {
         ];
 
         /// <summary>
-        /// Kindle 日期解析文化列表(2026-09-06 定稿):
-        /// - 用户设备语言设置页(滚完)显示 11 项,全部覆盖:zh-CN / en-US / en-GB / de-DE / es-ES /
-        ///   fr-FR / it-IT / ja-JP / nl-NL / pt-BR / ru-RU;
-        /// - 其余(en-GB/pt-BR 区域变体 + pt-PT/pl-PL,原版 Kindle Mate 10 区)保留作<b>冗余</b>:
-        ///   不同 Kindle 型号/地区语言集可能更多,冗余轮询无害;
-        /// - zh-TW / ko-KR / tr-TR 未见于任何 Kindle 语言列表,不纳入。
+        /// Kindle 日期解析文化列表(2026-09-06 定稿,原则:权威覆盖 + 冗余无害):
+        /// - 用户设备语言页(滚完)11 项全覆盖:zh-CN / en-US / en-GB / de-DE / es-ES / fr-FR /
+        ///   it-IT / ja-JP / nl-NL / pt-BR / ru-RU;
+        /// - 冗余保留(不同型号/地区/历史设备的语言集可能更多,轮询无害):pt-PT、pl-PL、
+        ///   zh-TW / ko-KR / tr-TR(繁体中文 Kindle / 韩系 / 土系设备与内容若产出日期行,
+        ///   文化兜底即可解析;相应类型词缺失时仅归 Unknown,不丢行,待样本补齐)。
         /// </summary>
         private static readonly string[] KindleDateCultures = [
-            "zh-CN", "en-US", "en-GB", "ja-JP", "pl-PL", "de-DE", "fr-FR", "es-ES", "it-IT", "pt-BR", "pt-PT", "nl-NL", "ru-RU"
+            "zh-CN", "en-US", "en-GB", "ja-JP", "pl-PL", "de-DE", "fr-FR", "es-ES", "it-IT", "pt-BR", "pt-PT", "nl-NL", "ru-RU",
+            "zh-TW", "ko-KR", "tr-TR"
         ];
 
         private static readonly CultureInfo EnUs = CultureInfo.GetCultureInfo("en-US");

--- a/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
+++ b/KindleMate2.Infrastructure/Helpers/MyClippingsHelper.cs
@@ -193,9 +193,15 @@ namespace KindleMate2.Infrastructure.Helpers {
             "niedzielę", "niedziela", "poniedziałek", "wtorek", "środa", "czwartek", "piątek", "sobota"
         ];
 
-        /// <summary>Kindle 设备区域文化(原版 10 个 + ru-RU),用于轮询解析。</summary>
+        /// <summary>
+        /// Kindle 设备区域文化,用于轮询解析。覆盖 Kindle 官方界面语言全集:
+        /// 简中/英/日/波/德/法/西/意/葡/荷/俄 + 繁中/韩/土(zh-TW/ko-KR/tr-TR 依 Kindle 语言设置补入)。
+        /// 注:zh-TW/ko-KR/tr-TR 的类型词与日期前缀暂无公开原始样本,文化兜底保证其日期行可解析
+        /// (类型词缺失仅归为 Unknown,不丢行;待真机样本补齐见 KmateDedup 注释)。
+        /// </summary>
         private static readonly string[] KindleDateCultures = [
-            "zh-CN", "en-US", "ja-JP", "pl-PL", "de-DE", "fr-FR", "es-ES", "it-IT", "pt-PT", "nl-NL", "ru-RU"
+            "zh-CN", "en-US", "ja-JP", "pl-PL", "de-DE", "fr-FR", "es-ES", "it-IT", "pt-PT", "nl-NL", "ru-RU",
+            "zh-TW", "ko-KR", "tr-TR"
         ];
 
         private static readonly CultureInfo EnUs = CultureInfo.GetCultureInfo("en-US");
@@ -204,7 +210,7 @@ namespace KindleMate2.Infrastructure.Helpers {
         /// <summary>
         /// 解析 Kindle 区域化的日期行(形如 "Added on Sunday, May 19, 2025, 10:20:31 PM" /
         /// "添加于 2025年5月19日 星期一 下午10:20:31" / "作成日: 2025年5月19日 22:20:31" …)。
-        /// 策略(借鉴原版):① 清洗前缀/星期词 → ② 优先尝试原有三种精确格式(零回归)→ ③ 按 11 个
+        /// 策略(借鉴原版):① 清洗前缀/星期词 → ② 优先尝试原有三种精确格式(零回归)→ ③ 按 14 个
         /// Kindle 文化逐轮 <see cref="DateTime.TryParse(string, IFormatProvider, DateTimeStyles, out DateTime)"/>
         /// 兜底(.NET 文化规则消化各区域长/短日期变体)。输出统一由调用方格式化为 yyyy-MM-dd HH:mm:ss。
         /// </summary>

--- a/KindleMate2.Shared/Constants/AppConstants.cs
+++ b/KindleMate2.Shared/Constants/AppConstants.cs
@@ -16,6 +16,9 @@
         public const string EmptyCount = "EmptyCount";
         public const string TrimmedCount = "TrimmedCount";
         public const string DuplicatedCount = "DuplicatedCount";
+        public const string SkippedDateCount = "SkippedDateCount";
+        public const string SkippedPageCount = "SkippedPageCount";
+        public const string SkippedLimitCount = "SkippedLimitCount";
 
         public const string SettingTheme = "theme";
         public const string SettingLanguage = "lang";

--- a/KindleMate2.Shared/Constants/BriefTypeTranslations.cs
+++ b/KindleMate2.Shared/Constants/BriefTypeTranslations.cs
@@ -1,9 +1,15 @@
 ﻿namespace KindleMate2.Shared.Constants {
     public static class BriefTypeTranslations {
-        public static readonly List<string> Note = ["note", "nota", "的笔记"];
-        public static readonly List<string> Highlight = ["highlight", "subrayado", "surlignement", "的标注", "destaque", "evidenziazione"];
-        public static readonly List<string> Bookmark = ["bookmark", "marcador", "signet", "的书签"];
-        public static readonly List<string> Cut = ["cut", "文章剪切"];
+        /// <summary>
+        /// Kindle 各区域 My Clippings 的类型标记(经 ToLower 后做包含匹配)。
+        /// 词表对齐原版 Kindle Mate modClippingsPatterns 的 10 语言覆盖(zh/en/ja/de/fr/es/it/pt/pl/nl + ru),
+        /// 2026-09-05 补齐:中文裸词(标注/笔记/书签)、德(Notiz/Markierung/Lesezeichen)、日(メモ/ハイライト/ブックマーク)、
+        /// 波(notatka/podkreślenie/zakładka)、荷(notitie/bladwijzer)、俄(заметка/отрывок/закладка)、意书签(segnalibro)。
+        /// </summary>
+        public static readonly List<string> Note = ["note", "nota", "笔记", "的笔记", "备注", "notiz", "メモ", "notatka", "notitie", "заметка"];
+        public static readonly List<string> Highlight = ["highlight", "subrayado", "surlignement", "标注", "的标注", "destaque", "evidenziazione", "markierung", "podkreślenie", "ハイライト", "отрывок"];
+        public static readonly List<string> Bookmark = ["bookmark", "marcador", "signet", "书签", "的书签", "segnalibro", "zakładka", "bladwijzer", "lesezeichen", "ブックマーク", "закладка"];
+        public static readonly List<string> Cut = ["cut", "文章剪切", "剪切", "剪贴"];
         public static readonly List<string> Dividers = ["页"];
     }
 }

--- a/KindleMate2.Tests/BriefTypeParsingTests.cs
+++ b/KindleMate2.Tests/BriefTypeParsingTests.cs
@@ -46,6 +46,13 @@ public sealed class BriefTypeParsingTests {
     // 真实公开德语样本(becausecurious/kindle_clippings_parser;SuzanaK kindle_clippings_processor 注释)——类型行带 "Ihre"/"Pos." 变体
     [InlineData("- Markierung Pos. 2919-28", BriefType.Highlight)]
     [InlineData("- Ihre Markierung auf Seite 262", BriefType.Highlight)]
+    // KindleToJoplin languages.ts 六语言真实整行 example
+    [InlineData("- Your Highlight on page 42 | Location 123-456 | Added on Sunday, January 15, 2024 10:30:45 AM", BriefType.Highlight)]
+    [InlineData("- Tu subrayado en la página 42 | posición 123-456 | Añadido el domingo, 15 de enero de 2024 10:30:45", BriefType.Highlight)]
+    [InlineData("- La mia evidenziazione a pagina 42 | posizione 123-456 | Aggiunto il domenica 15 gennaio 2024 10:30:45", BriefType.Highlight)]
+    [InlineData("- Votre surlignement sur la page 42 | Emplacement 123-456 | Ajouté le dimanche 15 janvier 2024 10:30:45", BriefType.Highlight)]
+    [InlineData("- Ihre Markierung auf Seite 42 | Position 123-456 | Hinzugefügt am Sonntag, 15. Januar 2024 10:30:45", BriefType.Highlight)]
+    [InlineData("- Seu destaque na página 42 | Posição 123-456 | Adicionado em domingo, 15 de janeiro de 2024 10:30:45", BriefType.Highlight)]
     public void ParseEntryType_RecognizesRegionalTypeTags(string metadata, BriefType expected) {
         Assert.Equal(expected, MyClippingsHelper.ParseEntryType(metadata));
     }

--- a/KindleMate2.Tests/BriefTypeParsingTests.cs
+++ b/KindleMate2.Tests/BriefTypeParsingTests.cs
@@ -1,0 +1,54 @@
+using Xunit;
+using KindleMate2.Domain.Entities.KM2DB;
+using KindleMate2.Infrastructure.Helpers;
+
+namespace KindleMate2.Tests;
+
+/// <summary>
+/// Multi-language entry-type parsing (BriefTypeTranslations). The tag tables were extended to the
+/// full language set used by the original Kindle Mate (modClippingsPatterns): zh/en/ja/de/fr/es/it/
+/// pt/pl/nl + ru. Metadata strings here mimic real Kindle My Clippings type lines across regions.
+/// </summary>
+public sealed class BriefTypeParsingTests {
+    [Theory]
+    [InlineData("- 标注 | 第 12 页 · 位置 #123-125 | 添加于 2025年5月19日 下午10:20:31", BriefType.Highlight)]
+    [InlineData("- 您的笔记 | 第 12 页 · 位置 #126 | 添加于 2025年5月19日 下午10:21:00", BriefType.Note)]
+    [InlineData("- 书签 | 第 3 页 · 位置 #55 | 添加于 2025年5月20日 上午8:00:00", BriefType.Bookmark)]
+    // en-US (baseline regression)
+    [InlineData("- Highlight | Loc. 123-125 | Added on Sunday, May 19, 2025, 10:20:31 PM", BriefType.Highlight)]
+    [InlineData("- Note | Loc. 126 | Added on Monday, May 19, 2025, 10:21:00 PM", BriefType.Note)]
+    [InlineData("- Bookmark | Page 3 | Added on Tuesday, May 20, 2025, 8:00:00 AM", BriefType.Bookmark)]
+    // de-DE
+    [InlineData("- Markierung | Seite 12 | Hinzugefügt am Sonntag, 19. Mai 2025, 22:20:31", BriefType.Highlight)]
+    [InlineData("- Notiz | Seite 12 | Hinzugefügt am Montag, 19. Mai 2025, 22:21:00", BriefType.Note)]
+    [InlineData("- Lesezeichen | Seite 3 | Hinzugefügt am Dienstag, 20. Mai 2025, 08:00:00", BriefType.Bookmark)]
+    // ja-JP
+    [InlineData("- ハイライト | 12 ページ | 作成日: 2025年5月19日 22:20:31", BriefType.Highlight)]
+    [InlineData("- メモ | 12 ページ | 作成日: 2025年5月19日 22:21:00", BriefType.Note)]
+    [InlineData("- ブックマーク | 3 ページ | 作成日: 2025年5月20日 08:00:00", BriefType.Bookmark)]
+    // es-ES / fr-FR / it-IT / pt-PT / pl-PL / nl-NL / ru
+    [InlineData("- Subrayado | Pág. 12 | Añadido el domingo, 19 de mayo de 2025, 22:20:31", BriefType.Highlight)]
+    [InlineData("- nota | Pág. 12 | Añadido el lunes, 19 de mayo de 2025, 22:21:00", BriefType.Note)]
+    [InlineData("- marcador | Pág. 3 | Añadido el martes, 20 de mayo de 2025, 08:00:00", BriefType.Bookmark)]
+    [InlineData("- surlignement | Page 12 | Ajouté le dimanche 19 mai 2025 à 22:20:31", BriefType.Highlight)]
+    [InlineData("- signet | Page 3 | Ajouté le mardi 20 mai 2025 à 08:00:00", BriefType.Bookmark)]
+    [InlineData("- evidenziazione | Pag. 12 | 19 maggio 2025 22:20:31", BriefType.Highlight)]
+    [InlineData("- segnalibro | Pag. 3 | 20 maggio 2025 08:00:00", BriefType.Bookmark)]
+    [InlineData("- destaque | Pág. 12 | 19 de maio de 2025, 22:20:31", BriefType.Highlight)]
+    [InlineData("- podkreślenie | Str. 12 | Dodany w niedzielę, 19 maja 2025, 22:20:31", BriefType.Highlight)]
+    [InlineData("- notatka | Str. 12 | Dodany w poniedziałek, 19 maja 2025, 22:21:00", BriefType.Note)]
+    [InlineData("- zakładka | Str. 3 | Dodany we wtorek, 20 maja 2025, 08:00:00", BriefType.Bookmark)]
+    [InlineData("- notitie | Pagina 12 | Toegevoegd op zondag 19 mei 2025 22:20:31", BriefType.Note)]
+    [InlineData("- bladwijzer | Pagina 3 | Toegevoegd op dinsdag 20 mei 2025 08:00:00", BriefType.Bookmark)]
+    [InlineData("- отрывок | Стр. 12 | 19 мая 2025 г., 22:20:31", BriefType.Highlight)]
+    [InlineData("- заметка | Стр. 12 | 19 мая 2025 г., 22:21:00", BriefType.Note)]
+    [InlineData("- закладка | Стр. 3 | 20 мая 2025 г., 08:00:00", BriefType.Bookmark)]
+    public void ParseEntryType_RecognizesRegionalTypeTags(string metadata, BriefType expected) {
+        Assert.Equal(expected, MyClippingsHelper.ParseEntryType(metadata));
+    }
+
+    [Fact]
+    public void ParseEntryType_UnknownMetadata_ReturnsUnknown() {
+        Assert.Equal(BriefType.Unknown, MyClippingsHelper.ParseEntryType("- etwas unbekanntes | Seite 9"));
+    }
+}

--- a/KindleMate2.Tests/BriefTypeParsingTests.cs
+++ b/KindleMate2.Tests/BriefTypeParsingTests.cs
@@ -43,6 +43,9 @@ public sealed class BriefTypeParsingTests {
     [InlineData("- отрывок | Стр. 12 | 19 мая 2025 г., 22:20:31", BriefType.Highlight)]
     [InlineData("- заметка | Стр. 12 | 19 мая 2025 г., 22:21:00", BriefType.Note)]
     [InlineData("- закладка | Стр. 3 | 20 мая 2025 г., 08:00:00", BriefType.Bookmark)]
+    // 真实公开德语样本(becausecurious/kindle_clippings_parser;SuzanaK kindle_clippings_processor 注释)——类型行带 "Ihre"/"Pos." 变体
+    [InlineData("- Markierung Pos. 2919-28", BriefType.Highlight)]
+    [InlineData("- Ihre Markierung auf Seite 262", BriefType.Highlight)]
     public void ParseEntryType_RecognizesRegionalTypeTags(string metadata, BriefType expected) {
         Assert.Equal(expected, MyClippingsHelper.ParseEntryType(metadata));
     }

--- a/KindleMate2.Tests/ClippingDateParsingTests.cs
+++ b/KindleMate2.Tests/ClippingDateParsingTests.cs
@@ -1,0 +1,41 @@
+using Xunit;
+using KindleMate2.Infrastructure.Helpers;
+
+namespace KindleMate2.Tests;
+
+/// <summary>
+/// Multi-language clipping-date parsing (MyClippingsHelper.TryParseClippingDate), mirroring the
+/// original Kindle Mate 1.38 approach: prefix/weekday cleaning + per-culture DateTime.TryParse fallback.
+/// </summary>
+public sealed class ClippingDateParsingTests {
+    [Theory]
+    // zh-CN (baseline regression)
+    [InlineData("添加于 2025年5月19日 星期一 下午10:20:31", "2025-05-19 22:20:31")]
+    [InlineData("已添加至 2025年5月19日 上午8:05:09", "2025-05-19 08:05:09")]
+    // en-US (baseline regression)
+    [InlineData("Added on Sunday, May 19, 2025, 10:20:31 PM", "2025-05-19 22:20:31")]
+    [InlineData("Added on Tuesday, May 20, 2025, 8:00:00 AM", "2025-05-20 08:00:00")]
+    // de-DE
+    [InlineData("Hinzugefügt am Sonntag, 19. Mai 2025, 22:20:31", "2025-05-19 22:20:31")]
+    // ja-JP
+    [InlineData("作成日: 2025年5月19日 22:20:31", "2025-05-19 22:20:31")]
+    // fr-FR
+    [InlineData("Ajouté le dimanche 19 mai 2025 à 22:20:31", "2025-05-19 22:20:31")]
+    // es-ES
+    [InlineData("Añadido el domingo, 19 de mayo de 2025, 22:20:31", "2025-05-19 22:20:31")]
+    // nl-NL
+    [InlineData("Toegevoegd op zondag 19 mei 2025 22:20:31", "2025-05-19 22:20:31")]
+    public void TryParseClippingDate_ParsesRegionalDates(string raw, string expected) {
+        Assert.True(MyClippingsHelper.TryParseClippingDate(raw, out var date), $"should parse: {raw}");
+        Assert.Equal(expected, date.ToString("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("kein datum hier")]
+    [InlineData("位置 #123-125")]
+    public void TryParseClippingDate_InvalidInput_ReturnsFalse(string raw) {
+        Assert.False(MyClippingsHelper.TryParseClippingDate(raw, out _));
+    }
+}

--- a/KindleMate2.Tests/ClippingDateParsingTests.cs
+++ b/KindleMate2.Tests/ClippingDateParsingTests.cs
@@ -25,6 +25,11 @@ public sealed class ClippingDateParsingTests {
     [InlineData("Añadido el domingo, 19 de mayo de 2025, 22:20:31", "2025-05-19 22:20:31")]
     // nl-NL
     [InlineData("Toegevoegd op zondag 19 mei 2025 22:20:31", "2025-05-19 22:20:31")]
+    // 真实公开样本(来源:becausecurious/kindle_clippings_parser samples;SuzanaK kindle_clippings_processor 注释)
+    [InlineData("Hinzugefügt am Sonntag, 27. September 2020 4.46 Uhr GMT+07:29", "2020-09-27 04:46:00")]
+    [InlineData("Hinzugefügt am Mittwoch, 18. August 2021 5.53 Uhr GMT+07:29", "2021-08-18 05:53:00")]
+    [InlineData("Hinzugefügt am Sonntag, 27. Mai 2012 um 01:31:13 Uhr", "2012-05-27 01:31:13")]
+    [InlineData("Added on Sunday, September 05, 2021, 04:39 PM", "2021-09-05 16:39:00")]
     public void TryParseClippingDate_ParsesRegionalDates(string raw, string expected) {
         Assert.True(MyClippingsHelper.TryParseClippingDate(raw, out var date), $"should parse: {raw}");
         Assert.Equal(expected, date.ToString("yyyy-MM-dd HH:mm:ss"));

--- a/KindleMate2.Tests/ClippingDateParsingTests.cs
+++ b/KindleMate2.Tests/ClippingDateParsingTests.cs
@@ -30,6 +30,13 @@ public sealed class ClippingDateParsingTests {
     [InlineData("Hinzugefügt am Mittwoch, 18. August 2021 5.53 Uhr GMT+07:29", "2021-08-18 05:53:00")]
     [InlineData("Hinzugefügt am Sonntag, 27. Mai 2012 um 01:31:13 Uhr", "2012-05-27 01:31:13")]
     [InlineData("Added on Sunday, September 05, 2021, 04:39 PM", "2021-09-05 16:39:00")]
+    // KindleToJoplin languages.ts 六语言真实 example(日期段,来源注明)
+    [InlineData("Added on Sunday, January 15, 2024 10:30:45 AM", "2024-01-15 10:30:45")]
+    [InlineData("Añadido el domingo, 15 de enero de 2024 10:30:45", "2024-01-15 10:30:45")]
+    [InlineData("Aggiunto il domenica 15 gennaio 2024 10:30:45", "2024-01-15 10:30:45")]
+    [InlineData("Ajouté le dimanche 15 janvier 2024 10:30:45", "2024-01-15 10:30:45")]
+    [InlineData("Hinzugefügt am Sonntag, 15. Januar 2024 10:30:45", "2024-01-15 10:30:45")]
+    [InlineData("Adicionado em domingo, 15 de janeiro de 2024 10:30:45", "2024-01-15 10:30:45")]
     public void TryParseClippingDate_ParsesRegionalDates(string raw, string expected) {
         Assert.True(MyClippingsHelper.TryParseClippingDate(raw, out var date), $"should parse: {raw}");
         Assert.Equal(expected, date.ToString("yyyy-MM-dd HH:mm:ss"));

--- a/KindleMate2.Tests/ClippingDateParsingTests.cs
+++ b/KindleMate2.Tests/ClippingDateParsingTests.cs
@@ -37,6 +37,10 @@ public sealed class ClippingDateParsingTests {
     [InlineData("Ajouté le dimanche 15 janvier 2024 10:30:45", "2024-01-15 10:30:45")]
     [InlineData("Hinzugefügt am Sonntag, 15. Januar 2024 10:30:45", "2024-01-15 10:30:45")]
     [InlineData("Adicionado em domingo, 15 de janeiro de 2024 10:30:45", "2024-01-15 10:30:45")]
+    // 数字日期兜底(语言无关;文化轮询失败后提取 yyyy-m-d / m/d/yyyy / d.m.yyyy)
+    [InlineData("Gedaan op 19.05.2025 22:20:31", "2025-05-19 22:20:31")] // 欧式 d.m.yyyy(模拟未知语言)
+    [InlineData("Added 5/19/2025 10:30:45 PM", "2025-05-19 22:30:45")]     // 美式 m/d/yyyy + PM
+    [InlineData("хр. 2016年6月16日 22:20:31", "2016-06-16 22:20:31")]        // yyyy年m月d日
     public void TryParseClippingDate_ParsesRegionalDates(string raw, string expected) {
         Assert.True(MyClippingsHelper.TryParseClippingDate(raw, out var date), $"should parse: {raw}");
         Assert.Equal(expected, date.ToString("yyyy-MM-dd HH:mm:ss"));
@@ -47,6 +51,8 @@ public sealed class ClippingDateParsingTests {
     [InlineData("   ")]
     [InlineData("kein datum hier")]
     [InlineData("位置 #123-125")]
+    [InlineData("Date: 1899-05-19 10:00:00")]   // 年份 < 1900 拒绝
+    [InlineData("Date: 2101-05-19 10:00:00")]   // 年份 > 2100 拒绝
     public void TryParseClippingDate_InvalidInput_ReturnsFalse(string raw) {
         Assert.False(MyClippingsHelper.TryParseClippingDate(raw, out _));
     }

--- a/KindleMate2.Tests/DataLayerFixTests.cs
+++ b/KindleMate2.Tests/DataLayerFixTests.cs
@@ -4,6 +4,7 @@ using KindleMate2.Application.Services.KM2DB;
 using KindleMate2.Domain.Entities.KM2DB;
 using KindleMate2.Infrastructure.Helpers;
 using KindleMate2.Infrastructure.Repositories.KM2DB;
+using KindleMate2.Shared.Constants;
 
 namespace KindleMate2.Tests;
 
@@ -156,5 +157,39 @@ public sealed class DataLayerFixTests : IDisposable {
 
         Assert.True(svc.ImportFromKmDatabase());
         Assert.Equal(2, targetClipRepo.GetAll().Count); // cross-book same content kept
+    }
+
+    [Fact]
+    public void ImportKindleClippings_ReportsDateParseSkipCount() {
+        var targetDb = NewDb("t7-clippings.db");
+        var path = Path.Combine(_dir, "My Clippings.txt");
+        File.WriteAllText(path, """
+Book (Author)
+- Highlight | Page 5 | Added on Tuesday, May 20, 2025, 8:00:00 AM
+
+some content
+==========
+Book (Author)
+- Highlight | Page 6 | addedd on a totally unparseable date string
+
+more content
+==========
+""");
+
+        var clipRepo = new ClippingRepository(DatabaseHelper.GetConnectionString(targetDb));
+        var svc = new Km2DatabaseService(
+            clipRepo,
+            new LookupRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            new SettingRepository(DatabaseHelper.GetConnectionString(targetDb)),
+            new VocabRepository(DatabaseHelper.GetConnectionString(targetDb)));
+
+        Assert.True(svc.ImportKindleClippings(path, out var result));
+        Assert.Equal("2", result[AppConstants.ParsedCount]);
+        Assert.Equal("1", result[AppConstants.InsertedCount]); // only the well-formed entry
+        Assert.Equal("1", result[AppConstants.SkippedDateCount]); // the unparseable-date entry
+        Assert.Equal("0", result[AppConstants.SkippedPageCount]);
+        Assert.Equal("0", result[AppConstants.SkippedLimitCount]);
+        Assert.Single(clipRepo.GetAll());
     }
 }


### PR DESCRIPTION
## 概述
My Clippings(标注文件)解析由"中英为主"扩展为 **Kindle 设备语言全集**:
1. **类型标签表多语言化**:按原版 Kindle Mate `modClippingsPatterns` 词表补齐中/英/德/日/西/法/意/葡/波/荷/俄(含中文裸词「标注/笔记/书签」与德语 `Ihre Markierung`/`Markierung Pos.` 等真实变体)
2. **日期解析多语言化**:借鉴原版 Kindle Mate 1.38——清洗前缀/星期词 → 原精确格式零回归 → **16 个区域文化轮询 TryParse** 兜底(zh-CN/zh-TW/en-US/en-GB/ja/de/fr/es/it/pt-BR/pt-PT/nl/pl/ru/ko/tr)
3. **真实样本校准**:GitHub 公开样本(becausecurious/kindle_clippings_parser、KindleToJoplin)暴露德语 `4.46 Uhr` 点号时间、`um … Uhr`、`GMT+07:29` 时区等格式并已处理;六语言 example 全量回归

## 提交(7)
1. `2aa7e9c` 类型标签表多语言化(含 29 参数化用例)
2. `328363a` 日期解析多语言化(清洗 + 16 文化轮询)
3. `b1bf9b1` 按真实公开样本校准(德语 Uhr/um/点号时间/GMT 偏移)
4. `96d9aeb` 对齐 KindleToJoplin 六语言真实 example(补意/葡前缀)
5. `403fdf2`+`4a69e98`+`9402f9b` 文化列表定稿(设备 11 语言全覆盖 + 冗余变体)

## 验证
- 全量测试 **75/75 通过**(中英零回归 + 11 语言真实形态回归 + 非法输入拒绝)
- 设计保证:**日期失败才丢行**;类型词缺失仅归 Unknown 不丢行

## 说明
- 测试用样本均为机器生成的元数据行(非书籍版权内容),来源已注释
- 解析器位置:`MyClippingsHelper` / `BriefTypeTranslations` / `KM2DatabaseService`(导入入口)