### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, 'dev-*']
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lzcapp/KindleMate2/security/code-scanning/1](https://github.com/lzcapp/KindleMate2/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/build.yml` at the workflow root so all jobs inherit least-privilege access unless overridden.  
For this workflow, the best minimal non-breaking setting is:

- `contents: read`

This preserves current functionality (`actions/checkout` + restore/build/test) while ensuring `GITHUB_TOKEN` is not implicitly granted broader rights.  
Change location: immediately after the `on:` trigger block (before `jobs:`), or near the top-level keys. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
