### PR TITLE
ci: 升级 Actions 至 Node 24 运行时(修复 Node 20 弃用告警)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout (with submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,12 @@ jobs:
           - { rid: win-x86,   self: 'true',  suffix: x86_runtime }
     steps:
       - name: Checkout (with submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
@@ -81,7 +81,7 @@ jobs:
           Write-Output "asset=$name" >> $env:GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: assets-${{ matrix.suffix }}
           path: KindleMate2_${{ matrix.suffix }}.zip
@@ -92,7 +92,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout (full history for notes)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -109,7 +109,7 @@ jobs:
           Write-Output "version=$v" >> $env:GITHUB_OUTPUT
 
       - name: Download all assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true
@@ -125,7 +125,7 @@ jobs:
           $body | Out-File -FilePath notes.md -Encoding utf8
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.ver.outputs.version }}
           name: ${{ steps.ver.outputs.version }}


### PR DESCRIPTION
针对 GitHub Actions 的 **Node.js 20 deprecation 警告**（node20 actions 被强制运行在 node24 上），将所有 workflow 使用的 actions 升级到 Node 24 运行时版本。

**变更内容**（2 个 workflow 文件，共 7 处）：

| Workflow | Action | 原版本(node20) | 新版本(node24) |
|---|---|---|---|
| build.yml | actions/checkout | v4 | v5 |
| build.yml | actions/setup-dotnet | v4 | v5 |
| release.yml | actions/checkout ×2 | v4 | v5 |
| release.yml | actions/setup-dotnet | v4 | v5 |
| release.yml | actions/upload-artifact | v4 | v6 |
| release.yml | actions/download-artifact | v4 | v7 |
| release.yml | softprops/action-gh-release | v2 | v3 |

**选版原则**：取**最低的 Node 24 主版本**，行为变更风险最小；upload-artifact v5 与 download-artifact v5/v6 经核实仍为 node20 运行时，故跳过。所有现有输入参数（submodules / dotnet-version / name / path / merge-multiple / tag_name / retention-days 等）在新版本中保持兼容。

> 注：commit 由 Git Data API 创建，非 GPG 签名；合并方式建议 Squash（合入 main 后即为常规签名/新提交）。