### PR TITLE
ci: 添加 Dependabot 自动更新 GitHub Actions 配置

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# 依赖自动更新(Dependabot)
+# GitHub Actions 每周一自动检查升级,以 PR 形式提出,避免 node 运行时弃用类版本漂移。
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,14 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "ci(deps)"
+  # NuGet 包依赖自动升级(csproj PackageReference)
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(nuget)"


### PR DESCRIPTION
针对 action 版本漂移问题（如本次 Node 20 → Node 24 需手动排查升级），添加 Dependabot 配置，让 GitHub Actions 依赖自动保持最新。

**配置内容**（`.github/dependabot.yml`）：
- ecosystem: `github-actions`，目录 `/`
- 每周一 09:00（Asia/Shanghai）自动检查升级
- 每个更新以独立 PR 提出（可审阅后合并），上限 5 个同时开放
- commit message 前缀 `ci(deps)`

**效果**：未来 actions 升级（含运行时弃用类）由 Dependabot 自动跟踪并提 PR，无需再手动核对各 action 的 node 运行时。

> 注：commit 由 Git Data API 创建，非 GPG 签名；合并建议 Squash。