### PR TITLE
fix: 适配 MediaDevices 2.0.0(GetDevices 移至 MediaDeviceManager)

### DIFF
--- a/KindleMate2.Application/KindleMate2.Application.csproj
+++ b/KindleMate2.Application/KindleMate2.Application.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Leisn.MarkdigToc" Version="0.1.3" />
-    <PackageReference Include="MediaDevices" Version="1.10.0" />
+    <PackageReference Include="MediaDevices" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
     <PackageReference Include="System.Management" Version="9.0.9" />
   </ItemGroup>

--- a/KindleMate2.Application/Services/DeviceManager.cs
+++ b/KindleMate2.Application/Services/DeviceManager.cs
@@ -273,7 +273,7 @@ public class DeviceManager : IDeviceManager {
     /// FriendlyName / Model are available before Connect().
     /// </summary>
     private static MediaDevice? FindKindleDevice() {
-        return MediaDevice.GetDevices()
+        return MediaDeviceManager.Instance.GetDevices()?
             .FirstOrDefault(d =>
                 d.FriendlyName.Contains(AppConstants.Kindle, StringComparison.InvariantCultureIgnoreCase) ||
                 d.Model.Contains(AppConstants.Kindle, StringComparison.InvariantCultureIgnoreCase));

--- a/KindleMate2.Application/Services/DeviceManager.cs
+++ b/KindleMate2.Application/Services/DeviceManager.cs
@@ -275,8 +275,8 @@ public class DeviceManager : IDeviceManager {
     private static MediaDevice? FindKindleDevice() {
         return MediaDeviceManager.Instance.GetDevices()?
             .FirstOrDefault(d =>
-                d.FriendlyName.Contains(AppConstants.Kindle, StringComparison.InvariantCultureIgnoreCase) ||
-                d.Model.Contains(AppConstants.Kindle, StringComparison.InvariantCultureIgnoreCase));
+                d.FriendlyName?.Contains(AppConstants.Kindle, StringComparison.InvariantCultureIgnoreCase) == true ||
+                d.Model?.Contains(AppConstants.Kindle, StringComparison.InvariantCultureIgnoreCase) == true);
     }
 
     private static void ReadMtpFile(MediaDevice device, string path, string fileName, string filePath) {

--- a/KindleMate2/KindleMate2.csproj
+++ b/KindleMate2/KindleMate2.csproj
@@ -141,7 +141,7 @@
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
 		<PackageReference Include="Leisn.MarkdigToc" Version="0.1.3" />
 		<PackageReference Include="Markdig" Version="0.42.0" />
-		<PackageReference Include="MediaDevices" Version="1.10.0" />
+		<PackageReference Include="MediaDevices" Version="2.0.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="ReaLTaiizor" Version="3.8.1.3" />


### PR DESCRIPTION
## 概述

适配 **MediaDevices 2.0.0**(2026-08 发布的 major 重写版)。修复 Dependabot 自动升级 PR(dependabot/nuget/KindleMate2.Application/multi-31b13e090c)引发的 CI 编译错误:

```
error CS0117: 'MediaDevice' does not contain a definition for 'GetDevices' (DeviceManager.cs:276)
```

## 变更内容

| 文件 | 改动 |
|---|---|
| `KindleMate2.Application/KindleMate2.Application.csproj` | MediaDevices `1.10.0` → `2.0.0` |
| `KindleMate2/KindleMate2.csproj` | MediaDevices `1.10.0` → `2.0.0`(主程序引用,实际无类型使用) |
| `KindleMate2.Application/Services/DeviceManager.cs` | `MediaDevice.GetDevices()` → `MediaDeviceManager.Instance.GetDevices()?`;`FriendlyName`/`Model` 在 2.0.0 为可空 `string?`,谓词改 `?.Contains(...) == true` 空安全写法 |

## 背景

MediaDevices 2.0.0 完全重写(线程安全/异步/AOT 化):
- **移除**了 `MediaDevice.GetDevices()` 静态工厂方法,枚举入口改为单例 `MediaDeviceManager.Instance.GetDevices()`(返回 `IEnumerable<MediaDevice>?`,可空)
- 已通过元数据解析逐项核对:`Connect/Disconnect/UploadFile/DeleteFile/GetDirectoryInfo/DownloadFile/IsConnected/Dispose/FriendlyName/Model` 等本仓库依赖的全部成员在 2.0.0 **均保留**(另新增 Async 版)
- 两个项目 TFM(`net8.0-windows`)兼容 2.0.0 的 `net8.0-windows7.0` 资产

## 测试(基于 PR 最终 HEAD `ad8adaf`)

- ✅ `dotnet build KindleMate2.sln -c Debug --no-restore --no-incremental`:0 错误(全量编译,排除增量缓存假象)
- ✅ `dotnet test KindleMate2.sln -c Debug --no-build`:81 通过 / 0 失败

## Review 结论

- 改动面小(1 处 API 调用 + 2 处包版本),与 2.0.0 官方 Demo(`MediaDeviceManager.Instance.GetDevices()?.ToList()`)一致
- `GetDevices()` 可空已用 `?.` 处理,无新增 NRE 风险;新增警告 0

## 待办提醒

- ⚠️ **建议 Kindle 真机回归一次 MTP 文件同步**(2.0.0 为重写版,代码层兼容但设备行为需实测)
- Dependabot 原升级 PR(multi-31b13e090c)与本分支内容一致,可关闭
