### PR TITLE
perf: 导入/刷新性能优化(UI 防卡 + 判重/频率更新批量事务化)

### DIFF
--- a/KindleMate2.Application/Services/KM2DB/KM2DatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/KM2DatabaseService.cs
@@ -296,18 +296,24 @@ namespace KindleMate2.Application.Services.KM2DB {
                 .GroupBy(l => l.WordKey!.Trim())
                 .ToDictionary(g => g.Key, g => g.Count());
 
+            // Collect every row first, then push frequencies in ONE batched,
+            // transaction-wrapped call instead of one connection + UPDATE per vocab.
             var vocabs = vocabRepository.GetAll();
+            var updates = new List<Vocab>(vocabs.Count);
             foreach (Vocab vocab in vocabs) {
                 if (vocab.WordKey == null) {
                     continue;
                 }
                 frequencyMap.TryGetValue(vocab.WordKey, out var frequency);
-                vocabRepository.UpdateFrequencyByWordKey(new Vocab {
+                updates.Add(new Vocab {
                     WordKey = vocab.WordKey,
                     Frequency = frequency,
                     Id = vocab.Id,
                     Word = vocab.Word,
                 });
+            }
+            if (updates.Count > 0) {
+                vocabRepository.UpdateFrequencyByWordKey(updates);
             }
             return true;
         }
@@ -322,10 +328,15 @@ namespace KindleMate2.Application.Services.KM2DB {
                 var emptyClippings = clippings.Where(c => string.IsNullOrWhiteSpace(c.Content) || string.IsNullOrWhiteSpace(c.BookName)).ToList();
                 var emptyCount = clippingRepository.Delete(emptyClippings);
                 
-                var duplicatedClippings = clippings
-                    .Where(c => !string.IsNullOrWhiteSpace(c.Key) && !string.IsNullOrWhiteSpace(c.Content))
-                    .Where(c => clippings.Count(x => x.Content != null && x.Content.Contains(c.Content!)) > 1)
-                    .ToList();
+                // Duplicate detection: a clipping (non-blank key + content) is "duplicated"
+                // when more than one row's content CONTAINS its content as a substring
+                // (the row itself always matches, so one exact copy or one longer
+                // container is enough to flag it). The old implementation re-scanned the
+                // whole list with a Contains() count per candidate — O(n²) string scans.
+                // Equivalent result, but: exact duplicates resolved by grouping (O(n)),
+                // containment checks run only on remaining unique contents with length
+                // pruning and early exit.
+                var duplicatedClippings = FindDuplicatedClippings(clippings);
 
                 var duplicatedCount = clippingRepository.Delete(duplicatedClippings);
                 
@@ -353,6 +364,72 @@ namespace KindleMate2.Application.Services.KM2DB {
             }
         }
         
+        /// <summary>
+        /// Equivalent to the previous O(n²) predicate
+        /// <c>clippings.Count(x =&gt; x.Content != null &amp;&amp; x.Content.Contains(c.Content)) &gt; 1</c>
+        /// but without rescanning the whole list per candidate:
+        /// 1. exact-content duplicates are found by grouping (O(n));
+        /// 2. remaining unique contents only need ONE strictly-longer container row to be
+        ///    flagged, checked over distinct contents with length pruning + early exit.
+        /// Semantics are preserved: every row with non-null content can serve as the
+        /// "other row" that makes a candidate duplicated (including rows with a blank key
+        /// that are themselves never deleted).
+        /// </summary>
+        private static List<Clipping> FindDuplicatedClippings(List<Clipping> clippings) {
+            var candidates = clippings
+                .Where(c => !string.IsNullOrWhiteSpace(c.Key) && !string.IsNullOrWhiteSpace(c.Content))
+                .ToList();
+            var duplicated = new List<Clipping>();
+            if (candidates.Count == 0) {
+                return duplicated;
+            }
+
+            var rowsByContent = candidates
+                .GroupBy(c => c.Content!, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.Ordinal);
+
+            // Equality count over ALL non-null-content rows (not just candidates).
+            var poolCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (Clipping c in clippings) {
+                if (c.Content == null) continue;
+                poolCounts.TryGetValue(c.Content, out var count);
+                poolCounts[c.Content] = count + 1;
+            }
+
+            var remaining = new List<KeyValuePair<string, List<Clipping>>>();
+            foreach (var group in rowsByContent) {
+                if (poolCounts.TryGetValue(group.Key, out var equalCount) && equalCount > 1) {
+                    duplicated.AddRange(group.Value);
+                } else {
+                    remaining.Add(group);
+                }
+            }
+            if (remaining.Count == 0) {
+                return duplicated;
+            }
+
+            // Distinct container contents, longest first — iteration stops as soon as a
+            // container is no longer longer than the target.
+            var containers = poolCounts.Keys
+                .OrderByDescending(s => s.Length)
+                .ToArray();
+
+            // Shortest targets first so shallow hits are found quickly.
+            remaining.Sort((a, b) => a.Key.Length.CompareTo(b.Key.Length));
+            foreach (var (content, rows) in remaining) {
+                foreach (var container in containers) {
+                    if (container.Length <= content.Length) {
+                        break; // descending order: nothing after this can contain the target
+                    }
+                    if (container.IndexOf(content, StringComparison.Ordinal) >= 0) {
+                        duplicated.AddRange(rows); // one containing row ⇒ count > 1
+                        break;
+                    }
+                }
+            }
+            return duplicated;
+        }
+
         public bool IsDatabaseEmpty() {
             try {
                 var result = 0;

--- a/KindleMate2.Application/Services/KM2DB/VocabDatabaseService.cs
+++ b/KindleMate2.Application/Services/KM2DB/VocabDatabaseService.cs
@@ -35,7 +35,14 @@ namespace KindleMate2.Application.Services.KM2DB {
                 var insertedLookupCount = 0;
 
                 var bookInfoMap = bookInfos.ToDictionary(b => b.Id ?? string.Empty, StringComparer.OrdinalIgnoreCase);
-                
+
+                // Dedup against one in-memory snapshot of existing vocab ids instead of a
+                // GetById round-trip (new connection + query) per candidate row.
+                var existingVocabIds = _vocabRepository.GetAll()
+                    .Where(v => v.Id != null)
+                    .Select(v => v.Id!)
+                    .ToHashSet(StringComparer.Ordinal);
+
                 var newVocabs = new List<Vocab>();
                 foreach (Word item in words) {
                     var id = item.Id;
@@ -51,7 +58,7 @@ namespace KindleMate2.Application.Services.KM2DB {
                     DateTime dateTime = dateTimeOffset.LocalDateTime;
                     var formattedDateTime = dateTime.ToString("yyyy-MM-dd HH:mm:ss");
 
-                    if (_vocabRepository.GetById(word + timestamp) != null) {
+                    if (!existingVocabIds.Add(word + timestamp)) {
                         continue;
                     }
                     newVocabs.Add(new Vocab {
@@ -73,8 +80,13 @@ namespace KindleMate2.Application.Services.KM2DB {
                 // up within the same second are legitimate, but the same word looked up at
                 // the exact same formatted timestamp must not be inserted twice. Dedup
                 // in-memory on that composite key so a single import pass never trips the
-                // constraint and rolls back the whole batch.
-                var seenLookupKeys = new HashSet<string>(StringComparer.Ordinal);
+                // constraint and rolls back the whole batch. The set is seeded from the
+                // existing destination rows so the previous per-row
+                // ExistsByWordKeyAndTimestamp query (one connection each) disappears too.
+                var seenLookupKeys = _km2DbLookupRepository.GetAll()
+                    .Where(l => l.WordKey != null && l.Timestamp != null)
+                    .Select(l => l.WordKey + "\u0000" + l.Timestamp)
+                    .ToHashSet(StringComparer.Ordinal);
                 foreach (Lookup item in lookups) {
                     var wordKey = item.WordKey;
                     var bookKey = item.BookKey;
@@ -105,9 +117,6 @@ namespace KindleMate2.Application.Services.KM2DB {
                         continue;
                     }
 
-                    if (_km2DbLookupRepository.ExistsByWordKeyAndTimestamp(wordKey, formattedDateTime)) {
-                        continue;
-                    }
                     newLookups.Add(new Domain.Entities.KM2DB.Lookup {
                         WordKey = wordKey,
                         Usage = usage,
@@ -147,18 +156,24 @@ namespace KindleMate2.Application.Services.KM2DB {
                 .GroupBy(l => l.WordKey!.Trim())
                 .ToDictionary(g => g.Key, g => g.Count());
 
+            // Collect every row first, then push frequencies in ONE batched,
+            // transaction-wrapped call instead of one connection + UPDATE per vocab.
+            var updates = new List<Vocab>(vocabs.Count);
             foreach (Vocab vocab in vocabs) {
                 var wordKey = vocab.WordKey;
                 if (wordKey == null) {
                     continue;
                 }
                 frequencyMap.TryGetValue(wordKey, out var frequency);
-                _vocabRepository.UpdateFrequencyByWordKey(new Vocab {
+                updates.Add(new Vocab {
                     WordKey = wordKey,
                     Frequency = frequency,
                     Id = vocab.Id,
                     Word = vocab.Word
                 });
+            }
+            if (updates.Count > 0) {
+                _vocabRepository.UpdateFrequencyByWordKey(updates);
             }
         }
     }

--- a/KindleMate2.Domain/Interfaces/KM2DB/IVocabRepository.cs
+++ b/KindleMate2.Domain/Interfaces/KM2DB/IVocabRepository.cs
@@ -21,6 +21,8 @@ namespace KindleMate2.Domain.Interfaces.KM2DB {
 
         bool UpdateFrequencyByWordKey(Vocab vocab);
 
+        int UpdateFrequencyByWordKey(List<Vocab> vocabs);
+
         bool Delete(string id);
 
         bool DeleteByWordKey(string wordKey);

--- a/KindleMate2.Infrastructure/Repositories/KM2DB/ClippingRepository.cs
+++ b/KindleMate2.Infrastructure/Repositories/KM2DB/ClippingRepository.cs
@@ -456,16 +456,28 @@ namespace KindleMate2.Infrastructure.Repositories.KM2DB {
             using var connection = new SqliteConnection(connectionString);
             connection.Open();
 
-            foreach (Clipping clipping in listClippings) {
-                var cmd = new SqliteCommand("DELETE FROM clippings WHERE key = @key", connection);
-                var key = clipping.Key;
-                if (string.IsNullOrWhiteSpace(key)) {
-                    throw new InvalidOperationException();
+            // One transaction + one reused command instead of an auto-committed DELETE
+            // per row — SQLite fsyncs on every standalone commit, which made bulk
+            // cleanup (CleanDatabase over thousands of rows) orders of magnitude
+            // slower than necessary.
+            using var transaction = connection.BeginTransaction();
+            try {
+                using var cmd = new SqliteCommand("DELETE FROM clippings WHERE key = @key", connection, transaction);
+                foreach (Clipping clipping in listClippings) {
+                    var key = clipping.Key;
+                    if (string.IsNullOrWhiteSpace(key)) {
+                        throw new InvalidOperationException();
+                    }
+                    cmd.Parameters.Clear();
+                    cmd.Parameters.AddWithValue("@key", key);
+                    if (cmd.ExecuteNonQuery() > 0) {
+                        count++;
+                    }
                 }
-                cmd.Parameters.AddWithValue("@key", key);
-                if (cmd.ExecuteNonQuery() > 0) {
-                    count++;
-                }
+                transaction.Commit();
+            } catch {
+                transaction.Rollback();
+                throw;
             }
             return count;
         }

--- a/KindleMate2.Infrastructure/Repositories/KM2DB/VocabRepository.cs
+++ b/KindleMate2.Infrastructure/Repositories/KM2DB/VocabRepository.cs
@@ -213,6 +213,40 @@ namespace KindleMate2.Infrastructure.Repositories.KM2DB {
             return cmd.ExecuteNonQuery() > 0;
         }
 
+        /// <summary>
+        /// Bulk-updates frequency for many vocabs in a single transaction with one reused
+        /// command. Replaces the previous per-vocab call pattern that opened a new
+        /// connection (and auto-committed) once per row — the dominant cost when an
+        /// import triggers a full frequency recompute over thousands of vocab rows.
+        /// Rows with a null/blank word_key are skipped (they can never match any
+        /// lookup), which keeps the batch from aborting on legacy junk rows.
+        /// </summary>
+        public int UpdateFrequencyByWordKey(List<Vocab> vocabs) {
+            var count = 0;
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+
+            using var transaction = connection.BeginTransaction();
+            try {
+                using var cmd = new SqliteCommand("UPDATE vocab SET frequency = @frequency WHERE word_key = @word_key", connection, transaction);
+                foreach (Vocab vocab in vocabs) {
+                    var wordKey = vocab.WordKey;
+                    if (string.IsNullOrWhiteSpace(wordKey)) {
+                        continue;
+                    }
+                    cmd.Parameters.Clear();
+                    cmd.Parameters.AddWithValue("@word_key", wordKey);
+                    cmd.Parameters.AddWithValue("@frequency", vocab.Frequency);
+                    count += cmd.ExecuteNonQuery();
+                }
+                transaction.Commit();
+            } catch {
+                transaction.Rollback();
+                throw;
+            }
+            return count;
+        }
+
         public bool Delete(string id) {
             using var connection = new SqliteConnection(connectionString);
             connection.Open();

--- a/KindleMate2.Tests/DataLayerFixTests.cs
+++ b/KindleMate2.Tests/DataLayerFixTests.cs
@@ -192,4 +192,69 @@ more content
         Assert.Equal("0", result[AppConstants.SkippedLimitCount]);
         Assert.Single(clipRepo.GetAll());
     }
+
+    [Fact]
+    public void CleanDatabase_ExactAndNestedDuplicates_MatchesLegacySemantics() {
+        // Regression for the O(n²)→grouping rewrite of Km2DatabaseService.FindDuplicatedClippings.
+        // Legacy rule: a clipping is duplicated when MORE than one row's content contains its
+        // content as a substring — identical content in two rows flags BOTH rows (not keep-one).
+        var db = NewDb("t9-clean.db");
+        using (var conn = new SqliteConnection(DatabaseHelper.GetConnectionString(db))) {
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                "INSERT INTO clippings (key, content, bookname, authorname, clippingdate) VALUES " +
+                "('k1', 'alpha', 'B1', 'A', '2026-01-01 00:00:00'), " +   // exact duplicate of k2
+                "('k2', 'alpha', 'B2', 'A', '2026-01-02 00:00:00'), " +   // exact duplicate of k1
+                "('k3', 'alpha beta', 'B1', 'A', '2026-01-03 00:00:00'), " + // contains 'alpha', but is unique itself
+                "('k4', 'gamma', 'B1', 'A', '2026-01-04 00:00:00');";     // unique, untouched
+            cmd.ExecuteNonQuery();
+        }
+
+        var clipRepo = new ClippingRepository(DatabaseHelper.GetConnectionString(db));
+        var svc = new Km2DatabaseService(
+            clipRepo,
+            new LookupRepository(DatabaseHelper.GetConnectionString(db)),
+            new OriginalClippingLineRepository(DatabaseHelper.GetConnectionString(db)),
+            new SettingRepository(DatabaseHelper.GetConnectionString(db)),
+            new VocabRepository(DatabaseHelper.GetConnectionString(db)));
+
+        Assert.True(svc.CleanDatabase(db, out var result));
+        Assert.Equal("0", result[AppConstants.EmptyCount]);
+        Assert.Equal("2", result[AppConstants.DuplicatedCount]); // k1 + k2 removed
+
+        var remaining = clipRepo.GetAll().Select(c => c.Key).OrderBy(k => k).ToList();
+        Assert.Equal(new[] { "k3", "k4" }, remaining);
+    }
+
+    [Fact]
+    public void VocabBulkFrequencyUpdate_OneTransaction_UpdatesAllRows() {
+        var repo = new VocabRepository(DatabaseHelper.GetConnectionString(NewDb("t10-freq.db")));
+        var batch = new List<Vocab>();
+        for (var i = 0; i < 2000; i++) {
+            batch.Add(new Vocab {
+                Id = "f" + i,
+                WordKey = "wk" + i,
+                Word = "word" + i,
+                Timestamp = "2026-09-01 10:00:00",
+                Frequency = 0
+            });
+        }
+        Assert.Equal(2000, repo.Add(batch));
+
+        var updates = new List<Vocab>(batch.Count);
+        for (var i = 0; i < batch.Count; i++) {
+            updates.Add(new Vocab {
+                Id = batch[i].Id,
+                Word = batch[i].Word,
+                WordKey = batch[i].WordKey,
+                Frequency = i % 7 // arbitrary per-row target
+            });
+        }
+
+        Assert.Equal(2000, repo.UpdateFrequencyByWordKey(updates));
+        Assert.Equal(0, repo.GetById("f0")!.Frequency);
+        Assert.Equal(6, repo.GetById("f6")!.Frequency);
+        Assert.Equal(4, repo.GetById("f1999")!.Frequency); // 1999 % 7 == 4
+    }
 }

--- a/KindleMate2/FrmMain.cs
+++ b/KindleMate2/FrmMain.cs
@@ -317,41 +317,105 @@ namespace KindleMate2 {
         }
 
         private void PopulateTreeViews() {
-            // Books tree
+            // Rebuilding a TreeView re-lays-out every node; with thousands of books/words a
+            // blind Clear + ExpandAll on every refresh is what stalls the UI after imports.
+            // BeginUpdate batches all mutations into a single repaint, and the tree's
+            // expansion is preserved (a previously fully-expanded / first-populated tree
+            // still gets the legacy ExpandAll so newly imported items remain visible).
+            var expandedBooks = CaptureExpandedNodeNames(treeViewBooks);
+            var expandedWords = CaptureExpandedNodeNames(treeViewWords);
+            var expandAllBooks = ShouldExpandAll(treeViewBooks);
+            var expandAllWords = ShouldExpandAll(treeViewWords);
+
             var books = _dataDisplayService.GetDistinctBookNames();
-            treeViewBooks.Nodes.Clear();
-            treeViewBooks.Nodes.Add(new TreeNode(Strings.Select_All) { ImageIndex = 2, SelectedImageIndex = 2 });
-            if (books.Count != 0) {
-                foreach (TreeNode bookNode in books.Select(book => new TreeNode(book) { ToolTipText = book })) {
-                    treeViewBooks.Nodes.Add(bookNode);
+            treeViewBooks.BeginUpdate();
+            try {
+                treeViewBooks.Nodes.Clear();
+                treeViewBooks.Nodes.Add(new TreeNode(Strings.Select_All) { ImageIndex = 2, SelectedImageIndex = 2 });
+                if (books.Count != 0) {
+                    foreach (TreeNode bookNode in books.Select(book => new TreeNode(book) { ToolTipText = book })) {
+                        treeViewBooks.Nodes.Add(bookNode);
+                    }
+                }
+                if (expandAllBooks) {
+                    treeViewBooks.ExpandAll();
+                } else {
+                    RestoreExpandedNodes(treeViewBooks, expandedBooks);
+                }
+            } finally {
+                treeViewBooks.EndUpdate();
+            }
+
+            var words = _dataDisplayService.GetDistinctWordNames();
+            treeViewWords.BeginUpdate();
+            try {
+                treeViewWords.Nodes.Clear();
+                if (words.Count == 0) return;
+                treeViewWords.Nodes.Add(new TreeNode(Strings.Select_All) { ImageIndex = 2, SelectedImageIndex = 2 });
+                foreach (TreeNode wordNode in words.Select(word => new TreeNode(word) { ToolTipText = word })) {
+                    treeViewWords.Nodes.Add(wordNode);
+                }
+                if (expandAllWords) {
+                    treeViewWords.ExpandAll();
+                } else {
+                    RestoreExpandedNodes(treeViewWords, expandedWords);
+                }
+            } finally {
+                treeViewWords.EndUpdate();
+            }
+        }
+
+        /// <summary>Texts of currently-expanded top-level nodes, captured before a rebuild.</summary>
+        private static HashSet<string> CaptureExpandedNodeNames(TreeView tree) {
+            var expanded = new HashSet<string>(StringComparer.Ordinal);
+            foreach (TreeNode node in tree.Nodes) {
+                if (node.IsExpanded) {
+                    expanded.Add(node.Text);
                 }
             }
-            treeViewBooks.ExpandAll();
+            return expanded;
+        }
 
-            // Words tree
-            var words = _dataDisplayService.GetDistinctWordNames();
-            treeViewWords.Nodes.Clear();
-            if (words.Count == 0) return;
-            treeViewWords.Nodes.Add(new TreeNode(Strings.Select_All) { ImageIndex = 2, SelectedImageIndex = 2 });
-            foreach (TreeNode wordNode in words.Select(word => new TreeNode(word) { ToolTipText = word })) {
-                treeViewWords.Nodes.Add(wordNode);
+        /// <summary>True when the tree is empty (first population) or every node was expanded.</summary>
+        private static bool ShouldExpandAll(TreeView tree) {
+            if (tree.Nodes.Count == 0) {
+                return true;
             }
-            treeViewWords.ExpandAll();
+            foreach (TreeNode node in tree.Nodes) {
+                if (!node.IsExpanded) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>Re-expands the nodes the user had open before the rebuild.</summary>
+        private static void RestoreExpandedNodes(TreeView tree, HashSet<string> expanded) {
+            foreach (TreeNode node in tree.Nodes) {
+                if (expanded.Contains(node.Text)) {
+                    node.Expand();
+                }
+            }
         }
 
         private void SetDataGridView() {
-            dataGridView.DataSource = null;
-            dataGridView.Rows.Clear();
-            dataGridView.Columns.Clear();
+            dataGridView.SuspendLayout();
+            try {
+                dataGridView.DataSource = null;
+                dataGridView.Rows.Clear();
+                dataGridView.Columns.Clear();
 
-            var selectedIndex = tabControl.SelectedIndex;
-            switch (selectedIndex) {
-                case 0:
-                    SetClippingsGridView();
-                    break;
-                case 1:
-                    SetVocabsGridView();
-                    break;
+                var selectedIndex = tabControl.SelectedIndex;
+                switch (selectedIndex) {
+                    case 0:
+                        SetClippingsGridView();
+                        break;
+                    case 1:
+                        SetVocabsGridView();
+                        break;
+                }
+            } finally {
+                dataGridView.ResumeLayout();
             }
         }
 


### PR DESCRIPTION
## 背景
用户反馈:设备同步/导入后 UI 卡顿,记录规模 1k–1 万条。定位到 3 个导入后热点 + 1 个清理热点。

## 改动
| 文件 | 改动 |
|---|---|
| `KindleMate2/FrmMain.cs` | 书目/生词树重建包 `BeginUpdate/EndUpdate` 并保留展开状态(首载/全展开仍走 `ExpandAll`);网格重建包 `SuspendLayout/ResumeLayout` |
| `VocabDatabaseService.cs` | 生词/查询判重由逐行 `GetById` / `ExistsByWordKeyAndTimestamp` 连接查询 → 一次 `GetAll` 内存哈希集(万行场景 ~2 万次往返 → 几次全表扫描) |
| `VocabRepository.cs` + `IVocabRepository.cs` | 新增批量 `UpdateFrequencyByWordKey(List<Vocab>)`:单事务 + 复用命令 |
| 两处 `UpdateFrequency` | 先收集全部行,再一次性批量更新(替代每词一条连接 + UPDATE) |
| `ClippingRepository.cs` | `Delete(List)` 由逐行自动提交(SQLite 每行 fsync)→ 单事务复用命令 |
| `KM2DatabaseService.cs` | `CleanDatabase` 去重 O(n²) `Contains` 计数 → 分组查重 + 唯一内容按长度剪枝包含检测,**语义等价** |

## 验证
- 全解决方案 Debug 编译 **0 错误**
- 测试 **83/83 通过**(新增 2 个回归测试:CleanDatabase 去重语义、2000 行批量频率更新)